### PR TITLE
Consolidate all classes to a single namespace

### DIFF
--- a/.travis/install_swoole.sh
+++ b/.travis/install_swoole.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-pecl install << EOF
+pecl install swoole << EOF
 `#enable debug/trace log support? [no] :`
 `#enable sockets support? [no] :`y
 `#enable openssl support? [no] :`

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -26,9 +26,9 @@ class ConfigProvider
     {
         return [
             'factories'  => [
-                ServerRequestInterface::class => Container\ServerRequestSwooleFactory::class,
-                RequestHandlerRunner::class   => Container\RequestHandlerSwooleRunnerFactory::class,
-                SwooleHttpServer::class       => Container\SwooleHttpServerFactory::class
+                ServerRequestInterface::class => ServerRequestSwooleFactory::class,
+                RequestHandlerRunner::class   => RequestHandlerSwooleRunnerFactory::class,
+                SwooleHttpServer::class       => SwooleHttpServerFactory::class
             ]
         ];
     }

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -7,14 +7,13 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Container;
+namespace Zend\Expressive\Swoole;
 
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Throwable;
-use Zend\Expressive\Swoole\Emitter\SwooleEmitter;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 

--- a/src/RequestHandlerSwooleRunnerFactory.php
+++ b/src/RequestHandlerSwooleRunnerFactory.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Container;
+namespace Zend\Expressive\Swoole;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;

--- a/src/ServerRequestSwooleFactory.php
+++ b/src/ServerRequestSwooleFactory.php
@@ -7,12 +7,11 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Container;
+namespace Zend\Expressive\Swoole;
 
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Zend\Diactoros\ServerRequest;
-use Zend\Expressive\Swoole\Stream\SwooleStream;
 
 use function Zend\Diactoros\marshalMethodFromSapi;
 use function Zend\Diactoros\marshalProtocolVersionFromSapi;

--- a/src/SwooleEmitter.php
+++ b/src/SwooleEmitter.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Emitter;
+namespace Zend\Expressive\Swoole;
 
 use Psr\Http\Message\ResponseInterface;
 use Swoole\Http\Response as SwooleHttpResponse;

--- a/src/SwooleHttpServerFactory.php
+++ b/src/SwooleHttpServerFactory.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Container;
+namespace Zend\Expressive\Swoole;
 
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Server as SwooleHttpServer;

--- a/src/SwooleStream.php
+++ b/src/SwooleStream.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole\Stream;
+namespace Zend\Expressive\Swoole;
 
 use InvalidArgumentException;
 use Psr\Http\Message\StreamInterface;

--- a/test/RequestHandlerSwooleRunnerFactoryTest.php
+++ b/test/RequestHandlerSwooleRunnerFactoryTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Container;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -16,8 +16,8 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
-use Zend\Expressive\Swoole\Container\RequestHandlerSwooleRunner;
-use Zend\Expressive\Swoole\Container\RequestHandlerSwooleRunnerFactory;
+use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
+use Zend\Expressive\Swoole\RequestHandlerSwooleRunnerFactory;
 
 class RequestHandlerSwooleRunnerFactoryTest extends TestCase
 {

--- a/test/RequestHandlerSwooleRunnerTest.php
+++ b/test/RequestHandlerSwooleRunnerTest.php
@@ -7,13 +7,13 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Container;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Http\Server\RequestHandlerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
-use Zend\Expressive\Swoole\Container\RequestHandlerSwooleRunner;
+use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
 class RequestHandlerSwooleRunnerTest extends TestCase

--- a/test/ServerRequestSwooleFactoryTest.php
+++ b/test/ServerRequestSwooleFactoryTest.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Container;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -15,8 +15,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 use Swoole\Http\Request as SwooleHttpRequest;
-use Zend\Expressive\Swoole\Container\ServerRequestSwooleFactory;
-use Zend\Expressive\Swoole\Stream\SwooleStream;
+use Zend\Expressive\Swoole\ServerRequestSwooleFactory;
+use Zend\Expressive\Swoole\SwooleStream;
 
 class ServerRequestSwooleFactoryTest extends TestCase
 {

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -7,12 +7,12 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Emitter;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Swoole\Http\Response as SwooleHttpResponse;
 use Zend\Diactoros\Response;
-use Zend\Expressive\Swoole\Emitter\SwooleEmitter;
+use Zend\Expressive\Swoole\SwooleEmitter;
 
 class SwooleEmitterTest extends TestCase
 {

--- a/test/SwooleHttpServerFactoryTest.php
+++ b/test/SwooleHttpServerFactoryTest.php
@@ -7,13 +7,13 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Container;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Swoole\Process;
-use Zend\Expressive\Swoole\Container\SwooleHttpServerFactory;
+use Zend\Expressive\Swoole\SwooleHttpServerFactory;
 
 class SwooleHttpServerFactoryTest extends TestCase
 {

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -7,13 +7,13 @@
 
 declare(strict_types=1);
 
-namespace ZendTest\Expressive\Swoole\Stream;
+namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 use Swoole\Http\Request as SwooleHttpRequest;
-use Zend\Expressive\Swoole\Stream\SwooleStream;
+use Zend\Expressive\Swoole\SwooleStream;
 
 class SwooleStreamTest extends TestCase
 {


### PR DESCRIPTION
We are offering only two concrete classes, and the rest are factories.  Since all are named well, there's no need for additional subnamespaces.

This patch moves all source code under the namespace `Zend\Expressive\Swoole`.