### PR TITLE
Response cookies now parsed by dflydev/fig-cookies, and emitted via \…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,13 +22,14 @@
     "require": {
         "php": "^7.1",
         "ext-swoole": "*",
-        "zendframework/zend-diactoros" : "^1.8",
-        "zendframework/zend-expressive" : "^3.0.2",
-        "zendframework/zend-httphandlerrunner": "^1.0.1",
+        "dflydev/fig-cookies": "^1.0 || ^2.0",
         "psr/container": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-message-implementation": "^1.0",
-        "psr/http-server-handler": "^1.0"
+        "psr/http-server-handler": "^1.0",
+        "zendframework/zend-diactoros": "^1.8",
+        "zendframework/zend-expressive": "^3.0.2",
+        "zendframework/zend-httphandlerrunner": "^1.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -8,33 +8,31 @@
     "packages": [
         {
             "name": "dflydev/fig-cookies",
-            "version": "v2.0.0",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
-                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66"
+                "reference": "56133681a2d0055f110c1fa51b88c129bc6ce1c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/a59857139b9e30978b5b802b3631b5eaf34e8c66",
-                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/56133681a2d0055f110c1fa51b88c129bc6ce1c9",
+                "reference": "56133681a2d0055f110c1fa51b88c129bc6ce1c9",
                 "shasum": ""
             },
             "require": {
-                "ext-pcre": "*",
-                "php": "^7.2",
-                "psr/http-message": "^1"
+                "php": ">=5.4",
+                "psr/http-message": "~1.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^4",
-                "phpstan/phpstan": "^0.10.1",
-                "phpunit/phpunit": "^7.2.6",
-                "squizlabs/php_codesniffer": "^3.3"
+                "codeclimate/php-test-reporter": "~0.1@dev",
+                "phpunit/phpunit": "~4.5",
+                "squizlabs/php_codesniffer": "~2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
@@ -58,7 +56,7 @@
                 "psr-7",
                 "psr7"
             ],
-            "time": "2018-07-11T06:54:37+00:00"
+            "time": "2015-06-03T01:35:56+00:00"
         },
         {
             "name": "fig/http-message-util",
@@ -2270,7 +2268,7 @@
     "minimum-stability": "stable",
     "stability-flags": [],
     "prefer-stable": false,
-    "prefer-lowest": false,
+    "prefer-lowest": true,
     "platform": {
         "php": "^7.1",
         "ext-swoole": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,65 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "10f724af32552255d3c19ce1ff14c75d",
+    "content-hash": "aeaf02278ce05aef35d474fe2ecf6908",
     "packages": [
+        {
+            "name": "dflydev/fig-cookies",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dflydev/dflydev-fig-cookies.git",
+                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/a59857139b9e30978b5b802b3631b5eaf34e8c66",
+                "reference": "a59857139b9e30978b5b802b3631b5eaf34e8c66",
+                "shasum": ""
+            },
+            "require": {
+                "ext-pcre": "*",
+                "php": "^7.2",
+                "psr/http-message": "^1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^4",
+                "phpstan/phpstan": "^0.10.1",
+                "phpunit/phpunit": "^7.2.6",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dflydev\\FigCookies\\": "src/Dflydev/FigCookies"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Beau Simensen",
+                    "email": "beau@dflydev.com"
+                }
+            ],
+            "description": "Cookies for PSR-7 HTTP Message Interface.",
+            "keywords": [
+                "cookies",
+                "psr-7",
+                "psr7"
+            ],
+            "time": "2018-07-11T06:54:37+00:00"
+        },
         {
             "name": "fig/http-message-util",
             "version": "1.1.2",

--- a/test/SwooleEmitterTest.php
+++ b/test/SwooleEmitterTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace ZendTest\Expressive\Swoole;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
 use Swoole\Http\Response as SwooleHttpResponse;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Swoole\SwooleEmitter;
@@ -67,7 +68,11 @@ class SwooleEmitterTest extends TestCase
         $response = (new Response())
             ->withStatus(200)
             ->withAddedHeader('Set-Cookie', 'foo=bar')
-            ->withAddedHeader('Set-Cookie', 'bar=baz');
+            ->withAddedHeader('Set-Cookie', 'bar=baz')
+            ->withAddedHeader(
+                'Set-Cookie',
+                'baz=qux; Domain=somecompany.co.uk; Path=/; Expires=Wed, 09 Jun 2021 10:18:14 GMT; Secure; HttpOnly'
+            );
 
         $this->assertTrue($this->emitter->emit($response));
 
@@ -75,7 +80,16 @@ class SwooleEmitterTest extends TestCase
             ->status(200)
             ->shouldHaveBeenCalled();
         $this->swooleResponse
-            ->header('Set-Cookie', 'foo=bar, bar=baz')
+            ->header('Set-Cookie', Argument::any())
+            ->shouldNotBeCalled();
+        $this->swooleResponse
+            ->cookie('foo', 'bar', 0, '/', '', false, false)
+            ->shouldHaveBeenCalled();
+        $this->swooleResponse
+            ->cookie('bar', 'baz', 0, '/', '', false, false)
+            ->shouldHaveBeenCalled();
+        $this->swooleResponse
+            ->cookie('baz', 'qux', 1623233894, '/', 'somecompany.co.uk', true, true)
             ->shouldHaveBeenCalled();
     }
 


### PR DESCRIPTION
…Swoole\Http\Response::cookie

Fixes #7

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
Emitting responses with multiple `Set-Cookie` headers.

  - [x] Detail the original, incorrect behavior.
Multiple `Set-Cookie` headers squashed into a single `Set-Cookie` header

  - [x] Detail the new, expected behavior.
Same multiple `Set-Cookie` headers emitted

  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [x] Is this related to quality assurance?
Cookies might be shadowed in some HTTP responses, possibly causing erratic behavior in websites (login, etc)

**Note**: This adds a new composer dependency: `dflydev/fig-cookies`