### PR TITLE
Handle Accept-Encoding for static resource request

### DIFF
--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -405,16 +405,15 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
      */
     private function getCompressionEncoding(SwooleHttpRequest $request) : array
     {
-        $acceptEncoding = $request->header['accept-encoding'];
-        $explodedAcceptEncoding = explode(',', $acceptEncoding);
-        foreach ($explodedAcceptEncoding as $encoding) {
-            $encoding = trim($encoding);
-            if ('gzip' === $encoding) {
+        $acceptEncodings = explode(',', $request->header['accept-encoding']);
+        foreach ($acceptEncodings as $acceptEncoding) {
+            $acceptEncoding = trim($acceptEncoding);
+            if ('gzip' === $acceptEncoding) {
                 return [
                     'gzip',
                     ZLIB_ENCODING_DEFLATE
                 ];
-            } elseif ('deflate' === $encoding) {
+            } elseif ('deflate' === $acceptEncoding) {
                 return [
                     'deflate',
                     ZLIB_ENCODING_GZIP

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -403,7 +403,6 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
     private function isGzipAvailable(SwooleHttpRequest $request): bool
     {
         return $this->gzip > 0
-            && function_exists('gzcompress')
             && isset($request->header['accept-encoding']);
     }
 

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -406,17 +406,17 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
     private function getCompressionEncoding(SwooleHttpRequest $request) : array
     {
         $acceptEncodings = explode(',', $request->header['accept-encoding']);
-        foreach ($acceptEncodings as $acceptEncoding) {
+        foreach ($acceptEncodings ?? [] as $acceptEncoding) {
             $acceptEncoding = trim($acceptEncoding);
             if ('gzip' === $acceptEncoding) {
                 return [
                     'gzip',
-                    ZLIB_ENCODING_DEFLATE
+                    ZLIB_ENCODING_GZIP
                 ];
             } elseif ('deflate' === $acceptEncoding) {
                 return [
                     'deflate',
-                    ZLIB_ENCODING_GZIP
+                    ZLIB_ENCODING_DEFLATE
                 ];
             }
         }

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -382,7 +382,7 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
                 $response->header('Content-Encoding', $contentEncoding, true);
                 $response->header('Connection', 'close', true);
                 $handle = fopen($staticFile, 'rb');
-                $params = array('level' => $this->gzip, 'window' => $compressionEncoding, 'memory' => 9);
+                $params = ['level' => $this->gzip, 'window' => $compressionEncoding, 'memory' => 9];
                 stream_filter_append($handle, 'zlib.deflate', STREAM_FILTER_READ, $params);
                 while (feof($handle) !== true) {
                     $response->write(fgets($handle, 4096));


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
`sendfile` method in swoole http response does not support `gzip` method, this pr compress static file via Zlib functions
  - [x] How will users use the new feature?
Define config `gzip.level` in `zend-expressive-swoole.swoole-http-server`, the range is 0 to 9, the higher the number, the higher the compression level, 0 means disable compression function.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.
