### PR TITLE
Remove dependency on zend-console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,6 @@
         "psr/http-message-implementation": "^1.0",
         "psr/http-server-handler": "^1.0",
         "psr/log": "^1.0",
-        "zendframework/zend-console": "^2.7",
         "zendframework/zend-diactoros": "^1.8",
         "zendframework/zend-expressive": "^3.0.2",
         "zendframework/zend-httphandlerrunner": "^1.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3470125009418b55197f2ef08526db2f",
+    "content-hash": "12c4c14daeb19671537f5719d4f31e3d",
     "packages": [
         {
             "name": "dflydev/fig-cookies",
@@ -18,13 +18,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/dflydev/dflydev-fig-cookies/zipball/883233c159d00d39e940bd12cfe42c0d23420c1c",
                 "reference": "883233c159d00d39e940bd12cfe42c0d23420c1c",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.4",
@@ -76,13 +70,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/20b2c280cb6914b7b83089720df44e490f4b42f0",
                 "reference": "20b2c280cb6914b7b83089720df44e490f4b42f0",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.3 || ^7.0",
@@ -132,13 +120,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
                 "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
@@ -187,13 +169,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
@@ -243,13 +219,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/439d92054dc06097f2406ec074a2627839955a02",
                 "reference": "439d92054dc06097f2406ec074a2627839955a02",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=7.0",
@@ -302,13 +272,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
                 "reference": "ea17eb1fb2c8df6db919cc578451a8013c6a0ae5",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=7.0",
@@ -361,13 +325,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": ">=5.3.0"
@@ -403,65 +361,6 @@
             "time": "2016-10-10T12:19:37+00:00"
         },
         {
-            "name": "zendframework/zend-console",
-            "version": "2.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-console.git",
-                "reference": "e8aa08da83de3d265256c40ba45cd649115f0e18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-console/zipball/e8aa08da83de3d265256c40ba45cd649115f0e18",
-                "reference": "e8aa08da83de3d265256c40ba45cd649115f0e18",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-filter": "^2.7.2",
-                "zendframework/zend-json": "^2.6 || ^3.0",
-                "zendframework/zend-validator": "^2.10.1"
-            },
-            "suggest": {
-                "zendframework/zend-filter": "To support DefaultRouteMatcher usage",
-                "zendframework/zend-validator": "To support DefaultRouteMatcher usage"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev",
-                    "dev-develop": "2.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Console\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Build console applications using getopt syntax or routing, complete with prompts",
-            "keywords": [
-                "ZendFramework",
-                "console",
-                "zf"
-            ],
-            "time": "2018-01-25T19:08:04+00:00"
-        },
-        {
             "name": "zendframework/zend-diactoros",
             "version": "1.8.5",
             "source": {
@@ -473,13 +372,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-diactoros/zipball/3e4edb822c942f37ade0d09579cfbab11e2fee87",
                 "reference": "3e4edb822c942f37ade0d09579cfbab11e2fee87",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0",
@@ -542,13 +435,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-escaper/zipball/31d8aafae982f9568287cb4dce987e6aff8fd074",
                 "reference": "31d8aafae982f9568287cb4dce987e6aff8fd074",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^5.6 || ^7.0"
@@ -593,13 +480,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-expressive/zipball/c6db5b1a7524414eee0637bb50b8eed32fd67794",
                 "reference": "c6db5b1a7524414eee0637bb50b8eed32fd67794",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -691,13 +572,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-expressive-router/zipball/072d6b0620f7e1e616cb60062425b4eedd1a0447",
                 "reference": "072d6b0620f7e1e616cb60062425b4eedd1a0447",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1.2",
@@ -760,13 +635,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-expressive-template/zipball/b8b9ece61ed598a58223638933e2fd703ae4a5e9",
                 "reference": "b8b9ece61ed598a58223638933e2fd703ae4a5e9",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.1"
@@ -819,13 +688,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-httphandlerrunner/zipball/5e4c1e82a8bb1585020eafd32c49ece5a6ee98df",
                 "reference": "5e4c1e82a8bb1585020eafd32c49ece5a6ee98df",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "php": "^7.1",
@@ -868,58 +731,6 @@
             "time": "2018-02-21T20:33:02+00:00"
         },
         {
-            "name": "zendframework/zend-stdlib",
-            "version": "3.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
-                "reference": "cd164b4a18b5d1aeb69be2c26db035b5ed6925ae",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpbench/phpbench": "^0.13",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Stdlib\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "SPL extensions, array utilities, error handlers, and more",
-            "keywords": [
-                "ZendFramework",
-                "stdlib",
-                "zf"
-            ],
-            "time": "2018-04-30T13:50:40+00:00"
-        },
-        {
             "name": "zendframework/zend-stratigility",
             "version": "3.0.2",
             "source": {
@@ -931,13 +742,7 @@
                 "type": "zip",
                 "url": "https://api.github.com/repos/zendframework/zend-stratigility/zipball/75b64558201807514734a9f46386816f2900d7f7",
                 "reference": "75b64558201807514734a9f46386816f2900d7f7",
-                "shasum": "",
-                "mirrors": [
-                    {
-                        "url": "https://dl.laravel-china.org/%package%/%reference%.%type%",
-                        "preferred": true
-                    }
-                ]
+                "shasum": ""
             },
             "require": {
                 "fig/http-message-util": "^1.1",

--- a/src/CommandLine.php
+++ b/src/CommandLine.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole;
+
+use stdClass;
+
+use function ctype_digit;
+
+class CommandLine
+{
+    private const TYPE_FLAG = 0b0001;
+    private const TYPE_INT  = 0b0010;
+
+    private const MESSAGE_HELP = <<< 'EOH'
+Usage:
+  %s [options] [<argument>]
+
+Arguments:
+  help                Display help for the command (this message)
+  start               Start the web server (this is the default if no
+                      argument is given)
+  stop                Stop the web server
+
+Options:
+  -d, --daemonize     Daemonize the web server when starting (run as a
+                      background process)
+  -h, --help          Display this message
+  -n, --num_workers   Set the number of worker processes; defaults to 1
+
+Help:
+  This command allows you to control the web server, including starting
+  and stopping it. The provided options --daemonize and --num_workers
+  allow you to control how the server operates when you start it; other
+  options may be provided via configuration; see the documentation for
+  all options:
+
+  https://docs.zendframework.com/zend-expressive-swoole/intro/#providing-additional-swoole-configuration
+
+  The --daemonize and --num_workers options are only relevant when calling
+  "start".
+
+EOH;
+
+    /**
+     * @var string[]
+     */
+    private $allowedActions = [
+        CommandLineOptions::ACTION_HELP,
+        CommandLineOptions::ACTION_START,
+        CommandLineOptions::ACTION_STOP,
+    ];
+
+    /**
+     * @var ?string
+     */
+    private $argument;
+
+    /**
+     * @var string[]
+     */
+    private $arguments;
+
+    /**
+     * @var string
+     */
+    private $commandName;
+
+    /**
+     * @var array[string, mixed]
+     */
+    private $defaultOptions = [
+        'action'      => CommandLineOptions::ACTION_START,
+        'daemonize'   => false,
+        'help'        => false,
+        'num_workers' => 1,
+    ];
+
+    /**
+     * @var callable
+     */
+    private $exit = 'exit';
+
+    /**
+     * @var array[string, mixed]
+     */
+    private $options = [];
+
+    /**
+     * @var array[string, int]
+     */
+    private $optionMap = [
+        'daemonize'   => self::TYPE_FLAG,
+        'help'        => self::TYPE_FLAG,
+        'num_workers' => self::TYPE_INT,
+    ];
+
+    /**
+     * @var array[string, string]
+     */
+    private $shortOptionMap = [
+        'd' => 'daemonize',
+        'h' => 'help',
+        'n' => 'num_workers',
+    ];
+
+    /**
+     * @var resource
+     */
+    private $stderrStream = STDERR;
+
+    /**
+     * @var resource
+     */
+    private $stdoutStream = STDOUT;
+
+    /**
+     * @throws Exception\RuntimeException if unable to discover CLI arguments
+     *     (e.g., if $argv is not registered).
+     */
+    public function __construct(array $arguments = null)
+    {
+        $arguments = $arguments ?: $this->discoverArguments();
+        $this->commandName = array_shift($arguments);
+        $this->arguments = $arguments;
+    }
+
+    public function parse() : ?CommandLineOptions
+    {
+        $args = $this->arguments;
+        $options = $this->defaultOptions;
+        $argument = null;
+
+        while (count($args) > 0) {
+            if (substr($args[0], 0, 2) == '--') {
+                $parsed = $this->parseOption($options, $args);
+                if (! $parsed) {
+                    return null;
+                }
+
+                $options = $parsed->options;
+                $args = $parsed->args;
+                continue;
+            }
+
+            if (substr($args[0], 0, 1) == '-') {
+                $parsed = $this->parseOption($options, $args);
+                if (! $parsed) {
+                    return null;
+                }
+
+                $args = $parsed->args;
+                $options = $parsed->options;
+                continue;
+            }
+
+            if (in_array($args[0], $this->allowedActions, true)
+                && null === $argument
+            ) {
+                $options['action'] = array_shift($args);
+                continue;
+            }
+
+            $this->emitHelpAndExit(
+                1,
+                sprintf('An unexpected argument was encountered: %s', $args[0])
+            );
+            return null;
+        }
+
+        if ($options['help']) {
+            $options['action'] = CommandLineOptions::ACTION_HELP;
+        }
+
+        return new CommandLineOptions(
+            $options['action'],
+            $options['daemonize'],
+            $options['num_workers']
+        );
+    }
+
+    /**
+     * Emit the help message and exit.
+     *
+     * Uses the method's $status argument as the exit code.
+     *
+     * THIS METHOD HAS SIDE EFFECTS:
+     *
+     * - Writes to either STDOUT or STDERR
+     * - Calls exit()
+     */
+    public function emitHelpAndExit(int $status = 0, string $errorMessage = null) : void
+    {
+        $message = str_replace("\n", PHP_EOL, self::MESSAGE_HELP);
+        $message = sprintf($message, $this->commandName);
+
+        if ($errorMessage) {
+            $message = sprintf('Error:%3$s  %1$s%3$s%3$s%2$s', $errorMessage, $message, PHP_EOL);
+        }
+
+        $status === 0
+            ? fwrite($this->stdoutStream, $message)
+            : fwrite($this->stderrStream, $message);
+
+        $exit = $this->exit;
+        $exit($status);
+    }
+
+    /**
+     * Set the function to use when exiting. This exists solely for unit
+     * testing purposes.
+     *
+     * @internal
+     */
+    public function setExitFunction(callable $exit) : void
+    {
+        $this->exit = $exit;
+    }
+
+    /**
+     * Set the stream to use for STDERR. This exists solely for unit testing
+     * purposes.
+     *
+     * @internal
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setStderrStream($stream) : void
+    {
+        if (! is_resource($stream)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'STDERR stream MUST be a resource; received %s',
+                is_object($stream) ? get_class($stream) : gettype($stream)
+            ));
+        }
+
+        $this->stderrStream = $stream;
+    }
+
+    /**
+     * Set the stream to use for STDOUT. This exists solely for unit testing
+     * purposes.
+     *
+     * @internal
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setStdoutStream($stream) : void
+    {
+        if (! is_resource($stream)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                'STDOUT stream MUST be a resource; received %s',
+                is_object($stream) ? get_class($stream) : gettype($stream)
+            ));
+        }
+
+        $this->stdoutStream = $stream;
+    }
+
+    /**
+     * @throws Exception\RuntimeException if unable to discover CLI arguments
+     *     (e.g., if $argv is not registered).
+     */
+    private function discoverArguments() : array
+    {
+        if (isset($_SERVER['argv'])) {
+            return $_SERVER['argv'];
+        }
+
+        global $argv;
+
+        if (is_array($argv)) {
+            return $argv;
+        }
+
+        throw new Exception\RuntimeException('Unable to discover CLI arguments');
+    }
+
+    private function parseOption(array $options, array $args) : ?stdClass
+    {
+        $optionWithParam = ltrim(array_shift($args), '-');
+        $option = $optionWithParam;
+        if (false !== strpos($optionWithParam, '=')) {
+            [$option, $value] = explode('=', $optionWithParam, 2);
+            array_unshift($args, $value);
+        }
+
+        if (in_array($option, array_keys($this->shortOptionMap), true)) {
+            $option = $this->shortOptionMap[$option];
+        }
+
+        if (! in_array($option, array_keys($this->optionMap), true)) {
+            $this->emitHelpAndExit(
+                1,
+                sprintf('An unexpected option was encountered: %s', $option)
+            );
+            return null;
+        }
+
+        switch ($this->optionMap[$option]) {
+            case self::TYPE_FLAG:
+                $options[$option] = true;
+                break;
+            case self::TYPE_INT:
+                $value = array_shift($args);
+                if (! ctype_digit($value)) {
+                    $this->emitHelpAndExit(
+                        1,
+                        sprintf('An unexpected value for the option "%s" was encountered: %s', $option, $value)
+                    );
+                    return null;
+                }
+                $options[$option] = (int) $value;
+                break;
+        }
+
+        return (object) [
+            'args' => $args,
+            'options' => $options,
+        ];
+    }
+}

--- a/src/CommandLineOptions.php
+++ b/src/CommandLineOptions.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole;
+
+class CommandLineOptions
+{
+    public const ACTION_HELP = 'help';
+    public const ACTION_START = 'start';
+    public const ACTION_STOP = 'stop';
+
+    /** @var string */
+    private $action;
+
+    /** @var bool */
+    private $daemonize;
+
+    /** @var int */
+    private $numWorkers;
+
+    public function __construct(string $action, bool $daemonize, int $numWorkers)
+    {
+        $this->action = $action;
+        $this->daemonize = $daemonize;
+        $this->numWorkers = $numWorkers;
+    }
+
+    public function getAction() : string
+    {
+        return $this->action;
+    }
+
+    public function daemonize() : bool
+    {
+        return $this->daemonize;
+    }
+
+    public function getNumberOfWorkers() : int
+    {
+        return $this->numWorkers;
+    }
+}

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -18,7 +18,6 @@ use Swoole\Http\Response as SwooleHttpResponse;
 use Swoole\Http\Server as SwooleHttpServer;
 use Swoole\Process as SwooleProcess;
 use Throwable;
-use Zend\Console\Getopt;
 use Zend\Expressive\Swoole\Exception;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
@@ -215,21 +214,20 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
      */
     public function run() : void
     {
-        $opts = new Getopt([
-            'd|daemonize'  => 'Daemonize the swoole server process',
-            'n|num_workers=i' => 'The number of the worker processes to start.',
-        ]);
-        $args = $opts->getArguments();
-        $action = $args[0] ?? null;
-        switch ($action) {
-            case 'stop':
+        $commandLine = new CommandLine();
+        $options = $commandLine->parse();
+        switch ($options->getAction()) {
+            case CommandLineOptions::ACTION_HELP:
+                $commandLine->emitHelpAndExit();
+                break;
+            case CommandLineOptions::ACTION_STOP:
                 $this->stopServer();
                 break;
-            case 'start':
+            case CommandLineOptions::ACTION_START:
             default:
                 $this->startServer([
-                    'daemonize' => $opts->getOption('daemonize') ? (bool) $opts->getOption('daemonize') : false,
-                    'worker_num' => $opts->getOption('num_workers') ? (int) $opts->getOption('num_workers') : 1,
+                    'daemonize' => $options->daemonize(),
+                    'worker_num' => $options->getNumberOfWorkers(),
                 ]);
                 break;
         }

--- a/test/CommandLineTest.php
+++ b/test/CommandLineTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Swoole\CommandLine;
+use Zend\Expressive\Swoole\CommandLineOptions;
+
+class CommandLineTest extends TestCase
+{
+    public function mockExit(CommandLine $commandLine, int $expectedStatus, string $message = null) : void
+    {
+        $commandLine->setExitFunction(function (int $status) use ($expectedStatus, $message) {
+            $message = $message ?: sprintf('Expected exit status of %d, but received %d', $expectedStatus, $status);
+            TestCase::assertSame($expectedStatus, $status, $message);
+        });
+    }
+
+    public function assertStreamContains(string $expected, $stream, string $message = null) : void
+    {
+        $message = $message ?: sprintf('Failed asserting stream contains "%s"', $expected);
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        $regex = sprintf('/%s/', preg_quote($expected, '/'));
+        TestCase::assertRegExp($regex, $contents, $message);
+    }
+
+    public function testConstructorDiscoversCommandAndArgumentsFromProvidedArray()
+    {
+        $commandLine = new CommandLine(['test.php', '--daemonize', '--num_workers', '5']);
+        $this->assertAttributeSame('test.php', 'commandName', $commandLine);
+        $this->assertAttributeSame(['--daemonize', '--num_workers', '5'], 'arguments', $commandLine);
+    }
+
+    public function unrecognizedArguments() : iterable
+    {
+        return [
+            'single argument' => [['unknown']],
+            'multiple arguments, invalid first' => [['unknown', 'start']],
+            'multiple arguments, valid first' => [['start', 'unknown']],
+        ];
+    }
+
+    /**
+     * @dataProvider unrecognizedArguments
+     */
+    public function testParseExitsWithErrorForUnrecognizedArguments(array $args)
+    {
+        array_unshift($args, 'command');
+        $commandLine = new CommandLine($args);
+
+        $stderrStream = fopen('php://memory', 'wb+');
+        $commandLine->setStderrStream($stderrStream);
+        $this->mockExit($commandLine, 1);
+
+        $this->assertNull($commandLine->parse());
+        $this->assertStreamContains('An unexpected argument was encountered', $stderrStream);
+    }
+
+    public function unrecognizedOptions() : iterable
+    {
+        return [
+            'unknown short flag' => [['-u']],
+            'unknown long flag' => [['--unknown']],
+            'unknown short flag preceding known argument' => [['-t', 'start']],
+            'unknown short flag following known argument' => [['start', '-t']],
+            'unknown long flag preceding known argument' => [['--test', 'start']],
+            'unknown long flag following known argument' => [['start', '--test']],
+        ];
+    }
+
+    /**
+     * @dataProvider unrecognizedOptions
+     */
+    public function testParseExitsWithErrorForUnrecognizedOptions(array $args)
+    {
+        array_unshift($args, 'command');
+        $commandLine = new CommandLine($args);
+
+        $stderrStream = fopen('php://memory', 'wb+');
+        $commandLine->setStderrStream($stderrStream);
+        $this->mockExit($commandLine, 1);
+
+        $this->assertNull($commandLine->parse());
+        $this->assertStreamContains('An unexpected option was encountered', $stderrStream);
+    }
+
+    public function testParseExitsWithErrorWhenOptionHasUnexpectedValue()
+    {
+        $args = ['command', 'start', '-n', 'string'];
+        $commandLine = new CommandLine($args);
+
+        $stderrStream = fopen('php://memory', 'wb+');
+        $commandLine->setStderrStream($stderrStream);
+        $this->mockExit($commandLine, 1);
+
+        $this->assertNull($commandLine->parse());
+        $this->assertStreamContains(
+            'An unexpected value for the option "num_workers" was encountered',
+            $stderrStream
+        );
+    }
+
+    public function validCommandLines() : iterable
+    {
+        // @codingStandardsIgnoreStart
+        return [
+            // 'name' => [$argv, $action, $daemonize, $numWorkers]
+            'empty' => [[], CommandLineOptions::ACTION_START, false, 1],
+            // actions only
+            'help' => [[CommandLineOptions::ACTION_HELP], CommandLineOptions::ACTION_HELP, false, 1],
+            'start' => [[CommandLineOptions::ACTION_START], CommandLineOptions::ACTION_START, false, 1],
+            'stop' => [[CommandLineOptions::ACTION_STOP], CommandLineOptions::ACTION_STOP, false, 1],
+            // --help
+            'short-help start leading' => [['-h', CommandLineOptions::ACTION_START], CommandLineOptions::ACTION_HELP, false, 1],
+            'short-help start trailing' => [[CommandLineOptions::ACTION_START, '-h'], CommandLineOptions::ACTION_HELP, false, 1],
+            'long-help start leading' => [['--help', CommandLineOptions::ACTION_START], CommandLineOptions::ACTION_HELP, false, 1],
+            'long-help start trailing' => [[CommandLineOptions::ACTION_START, '--help'], CommandLineOptions::ACTION_HELP, false, 1],
+            // --daemonize
+            'short-daemonize' => [[CommandLineOptions::ACTION_START, '-d'], CommandLineOptions::ACTION_START, true, 1],
+            'long-daemonize' => [[CommandLineOptions::ACTION_START, '--daemonize'], CommandLineOptions::ACTION_START, true, 1],
+            // --num_workers
+            'short-num_workers' => [[CommandLineOptions::ACTION_START, '-n', '5'], CommandLineOptions::ACTION_START, false, 5],
+            'short-num_workers with equals' => [[CommandLineOptions::ACTION_START, '-n=5'], CommandLineOptions::ACTION_START, false, 5],
+            'long-num_workers' => [[CommandLineOptions::ACTION_START, '--num_workers', '5'], CommandLineOptions::ACTION_START, false, 5],
+            'long-num_workers with equals' => [[CommandLineOptions::ACTION_START, '--num_workers=5'], CommandLineOptions::ACTION_START, false, 5],
+            // full start invocation
+            'full start trailing options daemonize first' => [[CommandLineOptions::ACTION_START, '-d', '-n', '5'], CommandLineOptions::ACTION_START, true, 5],
+            'full start trailing options daemonize last' => [[CommandLineOptions::ACTION_START, '-n', '5', '-d'], CommandLineOptions::ACTION_START, true, 5],
+            'full start leading options daemonize first' => [['-d', '--num_workers', '5', CommandLineOptions::ACTION_START], CommandLineOptions::ACTION_START, true, 5],
+            'full start leading options daemonize last' => [['--num_workers', '5', '--daemonize', CommandLineOptions::ACTION_START], CommandLineOptions::ACTION_START, true, 5],
+            'full start daemonize start num_workers' => [['--daemonize', CommandLineOptions::ACTION_START, '--num_workers=5'], CommandLineOptions::ACTION_START, true, 5],
+            'full start num_workers start daemonize' => [['--num_workers', '5', CommandLineOptions::ACTION_START, '-d'], CommandLineOptions::ACTION_START, true, 5],
+        ];
+        // @codingStandardsIgnoreEnd
+    }
+
+    /**
+     * @dataProvider validCommandLines
+     */
+    public function testParseReturnsCommandLineOptionsWithExpectedValues(
+        array $args,
+        string $expectedAction,
+        bool $expectedDaemonizeValue,
+        int $expectedNumberOfWorkers
+    ) {
+        array_unshift($args, 'command');
+        $commandLine = new CommandLine($args);
+
+        $options = $commandLine->parse();
+
+        $this->assertInstanceOf(CommandLineOptions::class, $options);
+        $this->assertSame($expectedAction, $options->getAction());
+        $this->assertSame($expectedDaemonizeValue, $options->daemonize());
+        $this->assertSame($expectedNumberOfWorkers, $options->getNumberOfWorkers());
+    }
+}


### PR DESCRIPTION
This patch removes the dependency on zend-console. It does so by adding two classes, `CommandLine` and `CommandLineOptions`. The first is responsible for parsing the CLI arguments and options, and the second is a value object with the results. In the situation that it cannot parse the command line (unknown options or arguments), it will emit an error message and the help message. When `--help`, `-h`, or `help` are part of the command line, it will emit the help message.

The code is based lightly on how zend-console's `Getopt` class works, but streamlined for the expected options and arguments of this package.