### PR TITLE
Add `reload` command for reload all workers

### DIFF
--- a/src/CommandLine.php
+++ b/src/CommandLine.php
@@ -55,6 +55,7 @@ EOH;
         CommandLineOptions::ACTION_HELP,
         CommandLineOptions::ACTION_START,
         CommandLineOptions::ACTION_STOP,
+        CommandLineOptions::ACTION_RELOAD,
     ];
 
     /**

--- a/src/CommandLineOptions.php
+++ b/src/CommandLineOptions.php
@@ -14,6 +14,7 @@ class CommandLineOptions
     public const ACTION_HELP = 'help';
     public const ACTION_START = 'start';
     public const ACTION_STOP = 'stop';
+    public const ACTION_RELOAD = 'reload';
 
     /** @var string */
     private $action;

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -223,7 +223,7 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
             case CommandLineOptions::ACTION_STOP:
                 $this->stopServer();
                 break;
-            case 'reload':
+            case CommandLineOptions::ACTION_RELOAD:
                 $this->reloadWorker();
                 break;
             case CommandLineOptions::ACTION_START:

--- a/src/RequestHandlerSwooleRunner.php
+++ b/src/RequestHandlerSwooleRunner.php
@@ -223,6 +223,9 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
             case CommandLineOptions::ACTION_STOP:
                 $this->stopServer();
                 break;
+            case 'reload':
+                $this->reloadWorker();
+                break;
             case CommandLineOptions::ACTION_START:
             default:
                 $this->startServer([
@@ -275,6 +278,26 @@ class RequestHandlerSwooleRunner extends RequestHandlerRunner
         }
         $this->pidManager->delete();
         $this->logger->info('Server stopped');
+    }
+
+    /**
+     * Reload all worker, notice that reload worker action can
+     * ONLY run in SWOOLE_PROCESS mode.
+     */
+    public function reloadWorker() : void
+    {
+        if (! $this->isRunning()) {
+            $this->logger->info('Server is not running yet');
+            return;
+        }
+        [$masterPid, ] = $this->pidManager->read();
+        $this->logger->info('Worker reloading ...');
+        $result = SwooleProcess::kill((int) $masterPid, SIGUSR1);
+        if (! $result) {
+            $this->logger->info('Worker reload failure');
+            return;
+        }
+        $this->logger->info('Worker reloaded');
     }
 
     /**


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
Provide `reload` command for reload all workers, this command ONLY run in `SWOOLE_PROCESS` mode, and ONLY can reload the code that loaded after worker start.
  - [x] How will users use the new feature?
When server running in `daemon` mode, you can run `php public/index.php reload` command to reload all workers, this action will reload the business codes that you modified.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
