### PR TITLE
Renames RequestHandlerSwooleRunner to SwooleRequestHandlerRunner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#20](https://github.com/zendframework/zend-expressive-swoole/pull/20) adds a new interface, `Zend\Expressive\Swoole\StaticResourceHandlerInterface`,
   and default implementation `Zend\Expressive\Swoole\StaticResourceHandler`,
   used to determine if a request is for a static file, and then to serve it; the
-  `RequestHandlerSwooleRunner` composes an instance now for providing static
+  `SwooleRequestHandlerRunner` composes an instance now for providing static
   resource serving capabilities.
 
   The default implementation uses custom middleware to allow providing common
@@ -38,8 +38,10 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
+- [#21](https://github.com/zendframework/zend-expressive-swoole/pull/21) renames `RequestHandlerSwooleRunner` (and its related factory) to `SwooleRequestHandlerRunner`.
+
 - [#20](https://github.com/zendframework/zend-expressive-swoole/pull/20) modifies the collaborators and thus constructor arguments
-  expected by the `RequestHandlerSwooleRunner`. The constructor now has the
+  expected by the `SwooleRequestHandlerRunner`. The constructor now has the
   following signature:
 
   ```php

--- a/docs/book/how_it_works.md
+++ b/docs/book/how_it_works.md
@@ -12,7 +12,7 @@ using the `on(string $name, callable $action)` method.
 The request handler implemented in zend-expressive-swoole is a runner that
 enables the execution of an Expressive application inside the `on('request')`
 event of `Swoole\Http\Server`. This runner is implemented in the
-`Zend\Expressive\Swoole\RequestHandlerSwooleRunner` class.
+`Zend\Expressive\Swoole\SwooleRequestHandlerRunner` class.
 
 The basic implementation looks similar to the following:
 

--- a/docs/book/logging.md
+++ b/docs/book/logging.md
@@ -21,13 +21,13 @@ log application details. All logs we emit use `Psr\Log\LogLevel::INFO`.
 
 To substitute your own logger, you have two options.
 
-If you are manually instantiating a `Zend\Expressive\Swoole\RequestHandlerSwooleRunner`
+If you are manually instantiating a `Zend\Expressive\Swoole\SwooleRequestHandlerRunner`
 instance, you may provide it as the sixth argument to the constructor:
 
 ```php
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
 
-$runner = new RequestHandlerSwooleRunner(
+$runner = new SwooleRequestHandlerRunner(
     $application,
     $serverRequestFactory,
     $serverRequestErrorResponseGenerator,
@@ -37,6 +37,6 @@ $runner = new RequestHandlerSwooleRunner(
 );
 ```
 
-If using the provided factory (`RequestHandlerSwooleRunnerFactory`) &amp; which
+If using the provided factory (`SwooleRequestHandlerRunnerFactory`) &amp; which
 is the default when using the functionality with Expressive &amp; you can
 provide the logger via the `Psr\Log\LoggerInterface` service.

--- a/docs/book/static-resources.md
+++ b/docs/book/static-resources.md
@@ -5,13 +5,13 @@ filesystem. zend-expressive-swoole provides that capability as well.
 
 To enable this, the package provides an alternate
 [`RequestHandlerRunner`](https://docs.zendframework.com/zend-httphandlerrunner/runner/)
-implementation via the class `Zend\Expressive\Swoole\RequestHandlerSwooleRunner`
+implementation via the class `Zend\Expressive\Swoole\SwooleRequestHandlerRunner`
 that performs two duties:
 
 - If a static resource is matched, it serves that.
 - Otherwise, it passes off handling to the composed application pipeline.
 
-Internally, the `RequestHandlerSwooleRunner` composes another class, a 
+Internally, the `SwooleRequestHandlerRunner` composes another class, a 
 `Zend\Expressive\Swoole\StaticResourceHandlerInterface` instance. This instance
 is first queried to determine if a static resource was matched, and, if so, then
 invoked in order to serve it.
@@ -105,7 +105,6 @@ The following demonstrates all currently available configuration options:
 
 ```php
 // config/autoload/swoole.local.php
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
 
 return [
     'zend-expressive-swoole' => [
@@ -196,7 +195,6 @@ The example which follows provides the following options:
 
 ```php
 // config/autoload/swoole.local.php
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
 
 return [
     'zend-expressive-swoole' => [
@@ -348,7 +346,7 @@ potentially disable returning the response body (via `disableContent()`).
 
 ## Alternative static resource handlers
 
-As noted at the beginning of this chapter, the the `RequestHandlerSwooleRunner`
+As noted at the beginning of this chapter, the the `SwooleRequestHandlerRunner`
 composes a `StaticResourceHandlerInterface` instance in order to determine if a
 resource was matched by the request, and then to serve it.
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -26,7 +26,7 @@ class ConfigProvider
         return [
             'factories'  => [
                 PidManager::class                     => PidManagerFactory::class,
-                RequestHandlerRunner::class           => RequestHandlerSwooleRunnerFactory::class,
+                RequestHandlerRunner::class           => SwooleRequestHandlerRunnerFactory::class,
                 ServerFactory::class                  => ServerFactoryFactory::class,
                 ServerRequestInterface::class         => ServerRequestSwooleFactory::class,
                 StaticResourceHandlerInterface::class => StaticResourceHandlerFactory::class,

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -37,7 +37,7 @@ use function usleep;
  * then the runner will use the composed error response generator to generate a
  * response, based on the exception or throwable raised.
  */
-class RequestHandlerSwooleRunner extends RequestHandlerRunner
+class SwooleRequestHandlerRunner extends RequestHandlerRunner
 {
     /**
      * Keep CWD in daemon mode.

--- a/src/SwooleRequestHandlerRunnerFactory.php
+++ b/src/SwooleRequestHandlerRunnerFactory.php
@@ -15,9 +15,9 @@ use Psr\Log\LoggerInterface;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 
-class RequestHandlerSwooleRunnerFactory
+class SwooleRequestHandlerRunnerFactory
 {
-    public function __invoke(ContainerInterface $container) : RequestHandlerSwooleRunner
+    public function __invoke(ContainerInterface $container) : SwooleRequestHandlerRunner
     {
         $staticResourceHandler = $container->has(StaticResourceHandlerInterface::class)
             ? $container->get(StaticResourceHandlerInterface::class)
@@ -26,7 +26,7 @@ class RequestHandlerSwooleRunnerFactory
             ? $container->get(LoggerInterface::class)
             : null;
 
-        return new RequestHandlerSwooleRunner(
+        return new SwooleRequestHandlerRunner(
             $container->get(ApplicationPipeline::class),
             $container->get(ServerRequestInterface::class),
             $container->get(ServerRequestErrorResponseGenerator::class),

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -18,13 +18,13 @@ use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 use Zend\Expressive\Swoole\Exception\InvalidConfigException;
 use Zend\Expressive\Swoole\PidManager;
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunnerFactory;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunnerFactory;
 use Zend\Expressive\Swoole\ServerFactory;
 use Zend\Expressive\Swoole\StaticResourceHandlerInterface;
 use Zend\Expressive\Swoole\StdoutLogger;
 
-class RequestHandlerSwooleRunnerFactoryTest extends TestCase
+class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 {
     public function setUp()
     {
@@ -88,9 +88,9 @@ class RequestHandlerSwooleRunnerFactoryTest extends TestCase
     {
         $this->configureAbsentStaticResourceHandler();
         $this->configureAbsentLoggerService();
-        $factory = new RequestHandlerSwooleRunnerFactory();
+        $factory = new SwooleRequestHandlerRunnerFactory();
         $runner = $factory($this->container->reveal());
-        $this->assertInstanceOf(RequestHandlerSwooleRunner::class, $runner);
+        $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeEmpty('staticResourceHandler', $runner);
         $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $runner);
     }
@@ -105,9 +105,9 @@ class RequestHandlerSwooleRunnerFactoryTest extends TestCase
             ->get(LoggerInterface::class)
             ->will([$this->logger, 'reveal']);
 
-        $factory = new RequestHandlerSwooleRunnerFactory();
+        $factory = new SwooleRequestHandlerRunnerFactory();
         $runner = $factory($this->container->reveal());
-        $this->assertInstanceOf(RequestHandlerSwooleRunner::class, $runner);
+        $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeSame($this->logger->reveal(), 'logger', $runner);
     }
 
@@ -121,9 +121,9 @@ class RequestHandlerSwooleRunnerFactoryTest extends TestCase
             ->get(StaticResourceHandlerInterface::class)
             ->will([$this->staticResourceHandler, 'reveal']);
 
-        $factory = new RequestHandlerSwooleRunnerFactory();
+        $factory = new SwooleRequestHandlerRunnerFactory();
         $runner = $factory($this->container->reveal());
-        $this->assertInstanceOf(RequestHandlerSwooleRunner::class, $runner);
+        $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeSame($this->staticResourceHandler->reveal(), 'staticResourceHandler', $runner);
     }
 }

--- a/test/SwooleRequestHandlerRunnerTest.php
+++ b/test/SwooleRequestHandlerRunnerTest.php
@@ -20,12 +20,12 @@ use Swoole\Http\Server as SwooleHttpServer;
 use Zend\Diactoros\Response;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 use Zend\Expressive\Swoole\PidManager;
-use Zend\Expressive\Swoole\RequestHandlerSwooleRunner;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
 use Zend\Expressive\Swoole\ServerFactory;
 use Zend\Expressive\Swoole\StaticResourceHandlerInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
-class RequestHandlerSwooleRunnerTest extends TestCase
+class SwooleRequestHandlerRunnerTest extends TestCase
 {
     public function setUp()
     {
@@ -61,7 +61,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
 
     public function testConstructor()
     {
-        $requestHandler = new RequestHandlerSwooleRunner(
+        $requestHandler = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,
@@ -70,7 +70,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
             $this->staticResourceHandler->reveal(),
             $this->logger
         );
-        $this->assertInstanceOf(RequestHandlerSwooleRunner::class, $requestHandler);
+        $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $requestHandler);
         $this->assertInstanceOf(RequestHandlerRunner::class, $requestHandler);
     }
 
@@ -94,7 +94,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
             ->sendStaticResource(Argument::any())
             ->shouldNotBeCalled();
 
-        $requestHandler = new RequestHandlerSwooleRunner(
+        $requestHandler = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,
@@ -122,7 +122,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
 
     public function testOnStart()
     {
-        $runner = new RequestHandlerSwooleRunner(
+        $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,
@@ -164,7 +164,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
             ->end($content)
             ->shouldBeCalled();
 
-        $runner = new RequestHandlerSwooleRunner(
+        $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,
@@ -211,7 +211,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
             ->sendStaticResource(Argument::any())
             ->shouldNotBeCalled();
 
-        $runner = new RequestHandlerSwooleRunner(
+        $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,
@@ -248,7 +248,7 @@ class RequestHandlerSwooleRunnerTest extends TestCase
             ->sendStaticResource($request, $response)
             ->shouldBeCalled();
 
-        $runner = new RequestHandlerSwooleRunner(
+        $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
             $this->serverRequestFactory,
             $this->serverRequestError,


### PR DESCRIPTION
The base name is `RequestHandlerRunner`; `Swoole` is the specific variation.