### PR TITLE
Improved logging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#26](https://github.com/zendframework/zend-expressive-swoole/pull/26) adds comprehensive access logging capabilities via a new subnamespace,
+  `Zend\Expressive\Swoole\Log`. Capabilities include support (most) of the
+  Apache log format placeholders (as well as the standard formats used by Apache
+  and Debian), and the ability to provide your own formatting mechanisms. Please
+  see the [logging documentation](https://docs.zendframework.com/zend-expressive-swoole/logging/)
+  for more information.
+
 - [#20](https://github.com/zendframework/zend-expressive-swoole/pull/20) adds a new interface, `Zend\Expressive\Swoole\StaticResourceHandlerInterface`,
   and default implementation `Zend\Expressive\Swoole\StaticResourceHandler`,
   used to determine if a request is for a static file, and then to serve it; the
@@ -16,6 +23,7 @@ All notable changes to this project will be documented in this file, in reverse 
   features such as HTTP client-side caching headers, handling `OPTIONS`
   requests, etc. Full capabilities include:
 
+  - Filtering by allowed extensions.
   - Emitting `405` statuses for unsupported HTTP methods.
   - Handling `OPTIONS` requests.
   - Handling `HEAD` requests.
@@ -40,7 +48,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - [#21](https://github.com/zendframework/zend-expressive-swoole/pull/21) renames `RequestHandlerSwooleRunner` (and its related factory) to `SwooleRequestHandlerRunner`.
 
-- [#20](https://github.com/zendframework/zend-expressive-swoole/pull/20) modifies the collaborators and thus constructor arguments
+- [#20](https://github.com/zendframework/zend-expressive-swoole/pull/20) and [#26](https://github.com/zendframework/zend-expressive-swoole/pull/26) modify the collaborators and thus constructor arguments
   expected by the `SwooleRequestHandlerRunner`. The constructor now has the
   following signature:
 
@@ -52,7 +60,7 @@ All notable changes to this project will be documented in this file, in reverse 
       Zend\Expressive\Swoole\PidManager $pidManager,
       Zend\Expressive\Swoole\ServerFactory $serverFactory,
       Zend\Expressive\Swoole\StaticResourceHandlerInterface $staticResourceHandler = null,
-      Psr\Logger\LoggerInterface $logger = null
+      Zend\Expressive\Swoole\Log\AccessLogInterface $logger = null
   ) {
   ```
 

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -99,9 +99,8 @@ return [
 ### Serving static files
 
 We support serving static files. By default, we serve files with extensions in
-the whitelist defined in the constant
-`Zend\Expressive\Swoole\StaticResourceHandler::DEFAULT_STATIC_EXTS`, which
-is derived from a [list of common web MIME types maintained by Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types).
+the whitelist defined in the constant `Zend\Expressive\Swoole\StaticResourceHandler\ContentTypeFilterMiddleware::DEFAULT_STATIC_EXTS`,
+which is derived from a [list of common web MIME types maintained by Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types).
 Our static resource capabilities are fairly comprehensive; please see the
 [chapter on static resources](static-resources.md) for full details on
 configuration.

--- a/docs/book/logging.md
+++ b/docs/book/logging.md
@@ -6,23 +6,101 @@ analytics, identification of invalid requests, and more.
 Out-of-the-box, Swoole does not do this. As such, we provide these capabilities
 with this integration.
 
-We log two items:
+We log a number of items:
 
 - When the web server starts, indicating the host and port on which it is running.
-- Each request, with the following details:
-  - Timestamp of the request
-  - Remote address of the client making the request
-  - Request method
-  - Request URI
+- When workers start, including the working directory and worker ID.
+- When the web server stops.
+- When the web server reloads workers.
+- Each request (more on this below)
 
 By default, logging is performed to STDOUT, using an internal logger. However,
 you can use any [PSR-3 compliant logger][https://www.php-fig.org/psr/psr-3/] to
-log application details. All logs we emit use `Psr\Log\LogLevel::INFO`.
+log application details. We emit logs detailing server operations using the
+priority `Psr\Log\LogLevel::NOTICE` (unless detailing an error, such as
+inability to reload)), while `Psr\Log\LogLevel::INFO` and `Psr\Log\LogLevel::ERROR`
+are used to log requests (errors are used for response statuses greater than or
+equal to 400).
 
-To substitute your own logger, you have two options.
+## Access Logs
+
+Technically, the `SwooleRequestHandlerRunner` doesn't use PSR-3 loggers
+directly, but, rather, instances of `Zend\Expressive\Swoole\Log\AccessLogInterface`.
+This package-specific interface extends the PSR-3 interface to add two methods:
+
+```php
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Swoole\Http\Request;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+
+interface AccessLogInterface extends LoggerInterface
+{
+    public function logAccessForStaticResource(
+        Request $request,
+        StaticResourceResponse $response
+    ) : void;
+
+    public function logAccessForPsr7Resource(
+        Request $request,
+        ResponseInterface $response
+    ) : void;
+}
+```
+
+To allow usage of a standard PSR-3 logger, we also provide a decorator,
+`Zend\Expressive\Swoole\Log\Psr3AccessLogDecorator`, which decorates the PSR-3
+logger and provides a standard implementation for the two methods listed above.
+If you have defined a PSR-3 `LoggerInterface` service in your application, it
+will be used automatically.
+
+### Formatting logs
+
+The Apache web server has long provided flexible and robust logging
+capabilities, and its formats are used across a variety of web servers and
+logging platforms. As such, we have chosen to use its formats for our standard
+implementation. However, we allow you to plug in your own system as needed.
+
+You can refer to the [Apache mod_log_config documentation](http://httpd.apache.org/docs/current/mod/mod_log_config.html)
+in order to understand the available placeholders available for format strings.
+
+Formatting is provided to the `Psr3AccessLogDecorator` via instances of the
+interface `Zend\Expressive\Swoole\Log\AccessLogFormatterInterface`:
+
+```php
+interface AccessLogFormatterInterface
+{
+    public function format(AccessLogDataMap $map) : string;
+}
+```
+
+`AccessLogDataMap` is a class used internally by the `Psr3AccessLogDecorator` in
+order to map Apache log placeholders to request/response values.
+
+Our default `AccessLogFormatterInterface` implementation, `AccessLogFormatter`,
+provides constants referencing the most common formats, but also allows you to
+use arbitrary log formats that use the standard Apache placeholders. The formats
+we include by default are:
+
+- `AccessLogFormatter::FORMAT_COMMON`: Apache common log format: `%h %l %u %t "%r" %>s %b`
+- `AccessLogFormatter::FORMAT_COMMON_VHOST`: Apache common log format + vhost: `%v %h %l %u %t "%r" %>s %b`
+- `AccessLogFormatter::FORMAT_COMBINED`: Apache combined log format: `%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"`
+- `AccessLogFormatter::FORMAT_REFERER`: `%{Referer}i -> %U`
+- `AccessLogFormatter::FORMAT_AGENT`: `%{User-Agent}i`
+- `AccessLogFormatter::FORMAT_VHOST`: Alternative Apache vhost format: '%v %l %u %t "%r" %>s %b';
+- `AccessLogFormatter::FORMAT_COMMON_DEBIAN`: Debian variant of common log format: `%h %l %u %t “%r” %>s %O`;
+- `AccessLogFormatter::FORMAT_COMBINED_DEBIAN`: Debian variant of combined log format: `%h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i”`;
+- `AccessLogFormatter::FORMAT_VHOST_COMBINED_DEBIAN`: Debian variant of combined log format + vhost: `%v:%p %h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i"`;
+
+## Configuring a logger
+
+You may subsitute your own logger implementation into the Swoole request handler
+runner.
+
+### Manual usage
 
 If you are manually instantiating a `Zend\Expressive\Swoole\SwooleRequestHandlerRunner`
-instance, you may provide it as the sixth argument to the constructor:
+instance, you may provide it as the seventh argument to the constructor:
 
 ```php
 use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
@@ -31,12 +109,44 @@ $runner = new SwooleRequestHandlerRunner(
     $application,
     $serverRequestFactory,
     $serverRequestErrorResponseGenerator,
-    $swooleHttpServer,
-    $config,
-    $logger // <-- PSR-3 logger instance
+    $pidManager,
+    $serverFactory,
+    $staticResourceHandler,
+    $logger // <-- AccessLoggerInterface instance
 );
 ```
 
-If using the provided factory (`SwooleRequestHandlerRunnerFactory`) &amp; which
-is the default when using the functionality with Expressive &amp; you can
-provide the logger via the `Psr\Log\LoggerInterface` service.
+### Container usage
+
+If you are using a [PSR-11](https://www.php-fig.org/psr/psr-11/) container, the
+`SwooleRequestHandlerRunnerFactory` will retrieve a log instance using the
+`Zend\Expressive\Swoole\Log\AccessLogInterface` service.
+
+You have two options for substituting your own logger from there.
+
+First, you can create your own factory that produces an `AccessLogInterface`
+instance, and map it to the service. This is the best route if you want to write
+your own implementation, or want to use a different PSR-3 logger service.
+
+If you are okay with re-using your existing PSR-3 logger, the provided
+`Zend\Expressive\Swoole\Log\AccessLogFactory` will use the
+`Psr\Log\LoggerInterface` service to create a `Psr3AccessLogDecorator` instance.
+
+This factory also allows you to specify a custom `AccessLogFormatterInterface`
+instance if you want. It will look up a service by the fully-qualified interface
+name, and use it if present. Otherwise, it creates an `AccessLogFormatter`
+instance for you.
+
+The factory will also look at the following configuration values:
+
+```php
+'zend-expressive-swoole' => [
+    'swoole-http-server' => [
+        'logger' => [
+            'format' => string, // one of the AccessLogFormatter::FORMAT_*
+                                // constants, or a custom format string
+            'use-hostname-lookups' => bool, // Set to true to enable hostname lookups
+        ],
+    ],
+],
+```

--- a/docs/book/static-resources.md
+++ b/docs/book/static-resources.md
@@ -24,8 +24,8 @@ serve it.
 
 ## Middleware
 
-The `StaticResourceHandler` implementation also provides the ability to compose
-a queue of middleware to execute when attempting to serve a matched file.  Using
+The `StaticResourceHandler` implementation performs its work by composing a
+queue of middleware to execute when attempting to serve a matched file. Using
 this approach, we are able to provide a configurable set of capabilities for
 serving static resources. What we currently provide is as follows:
 
@@ -353,6 +353,8 @@ class StaticResourceResponse
 
 Most middleware will conditionally set the status, one or more headers, and
 potentially disable returning the response body (via `disableContent()`).
+Middleware that restricts access or filters out specific files will also use
+`markAsFailure()`.
 
 > ### Providing an alternative mechanism for sending response content
 > 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -25,6 +25,7 @@ class ConfigProvider
     {
         return [
             'factories'  => [
+                Log\AccessLogInterface::class         => Log\AccessLogFactory::class,
                 PidManager::class                     => PidManagerFactory::class,
                 RequestHandlerRunner::class           => SwooleRequestHandlerRunnerFactory::class,
                 ServerFactory::class                  => ServerFactoryFactory::class,

--- a/src/Log/AccessLogDataMap.php
+++ b/src/Log/AccessLogDataMap.php
@@ -1,0 +1,451 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ *
+ * Parts of this class are derived from middlewares/access-log:
+ * @copyright Copyright (c) 2018 Oscar Otero (https://github.com/middlewares/access-log/blob/master/LICENSE)
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+use Psr\Http\Message\ResponseInterface as PsrResponse;
+use Swoole\Http\Request as SwooleHttpRequest;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+
+use function filter_var;
+use function function_exists;
+use function getenv;
+use function getcwd;
+use function gethostbyaddr;
+use function gethostname;
+use function http_build_query;
+use function implode;
+use function is_string;
+use function microtime;
+use function preg_match;
+use function round;
+use function sprintf;
+use function strftime;
+use function substr;
+
+use const FILTER_FLAG_IPV4;
+use const FILTER_FLAG_IPV6;
+use const FILTER_VALIDATE_IP;
+
+class AccessLogDataMap
+{
+    private const HOST_PORT_REGEX = '/^(?P<host>.*?)((?<!\]):(?P<port>\d+))?$/';
+
+    /**
+     * Timestamp when created, indicating end of request processing.
+     *
+     * @var float
+     */
+    private $endTime;
+
+    /**
+     * @var SwooleHttpRequest
+     */
+    private $request;
+
+    /**
+     * @var ?PsrResponse
+     */
+    private $psrResponse;
+
+    /**
+     * Whether or not to do a hostname lookup when retrieving the remote host name
+     *
+     * @var bool
+     */
+    private $useHostnameLookups;
+
+    /**
+     * @var StaticResourceResponse
+     */
+    private $staticResource;
+
+    public static function createWithPsrResponse(
+        SwooleHttpRequest $request,
+        PsrResponse $response,
+        bool $useHostnameLookups = false
+    ) : self {
+        $map = new self($request, $useHostnameLookups);
+        $map->psrResponse = $response;
+        return $map;
+    }
+
+    public static function createWithStaticResource(
+        SwooleHttpRequest $request,
+        StaticResourceResponse $response,
+        bool $useHostnameLookups = false
+    ) : self {
+        $map = new self($request, $useHostnameLookups);
+        $map->staticResource = $response;
+        return $map;
+    }
+
+    /**
+     * Client IP address of the request (%a)
+     */
+    public function getClientIp() : string
+    {
+        return $this->getLocalIp();
+    }
+
+    /**
+     * Local IP-address (%A)
+     */
+    public function getLocalIp() : string
+    {
+        return $this->getServerParamIp('REMOTE_ADDR');
+    }
+
+    /**
+     * Filename (%f)
+     *
+     * @todo We likely need a way of injecting the gateway script, instead of
+     *     assuming it's getcwd() . /public/index.php.
+     * @todo We likely need a way of injecting the document root, instead of
+     *     assuming it's getcwd() . /public.
+     */
+    public function getFilename() : string
+    {
+        if ($this->psrResponse) {
+            return getcwd() . '/public/index.php';
+        }
+        return getcwd() . '/public' . $this->getServerParam('PATH_INFO');
+    }
+
+    /**
+     * Size of the message in bytes, excluding HTTP headers (%B, %b)
+     */
+    public function getBodySize(string $default) : string
+    {
+        if ($this->psrResponse) {
+            return (string) $this->psrResponse->getBody()->getSize() ?: $default;
+        }
+        return (string) $this->staticResource->getContentLength() ?: $default;
+    }
+
+    /**
+     * Remote hostname (%h)
+     * Will log the IP address if hostnameLookups is false.
+     */
+    public function getRemoteHostname() : string
+    {
+        $ip = $this->getServerParamIp('REMOTE_ADDR');
+
+        return $ip !== '-' && $this->useHostnameLookups
+            ? gethostbyaddr($ip)
+            : $ip;
+    }
+
+    /**
+     * The message protocol (%H)
+     */
+    public function getProtocol() : string
+    {
+        return $this->getServerParam('server_protocol');
+    }
+
+    /**
+     * The request method (%m)
+     */
+    public function getMethod() : string
+    {
+        return $this->getServerParam('request_method');
+    }
+
+    /**
+     * Returns a message header
+     */
+    public function getRequestHeader(string $name) : string
+    {
+        return $this->request->header[strtolower($name)] ?? '-';
+    }
+
+    /**
+     * Returns a message header
+     */
+    public function getResponseHeader(string $name) : string
+    {
+        if ($this->psrResponse) {
+            return $this->psrResponse->getHeaderLine($name) ?: '-';
+        }
+        return $this->staticResource->getHeader($name) ?: '-';
+    }
+
+    /**
+     * Returns a environment variable (%e)
+     */
+    public function getEnv(string $name) : string
+    {
+        return getenv($name) ?: '-';
+    }
+
+    /**
+     * Returns a cookie value (%{VARNAME}C)
+     */
+    public function getCookie(string $name) : string
+    {
+        return $this->request->cookie[$name] ?? '-';
+    }
+
+    /**
+     * The canonical port of the server serving the request. (%p)
+     */
+    public function getPort(string $format) : string
+    {
+        switch ($format) {
+            case 'canonical':
+            case 'local':
+                preg_match(self::HOST_PORT_REGEX, $this->request->header['host'] ?? '', $matches);
+                $port = $matches['port'] ?? null;
+                $port = $port ?: $this->getServerParam('server_port', '80');
+                $scheme = $this->getServerParam('https', '');
+                return $scheme && $port === '80' ? '443' : $port;
+            default:
+                return '-';
+        }
+    }
+
+    /**
+     * The query string (%q)
+     * (prepended with a ? if a query string exists, otherwise an empty string).
+     */
+    public function getQuery() : string
+    {
+        $query = $this->request->get;
+        return [] === $query ? '' : sprintf('?%s', http_build_query($query));
+    }
+
+    /**
+     * Status. (%s)
+     */
+    public function getStatus() : string
+    {
+        return $this->psrResponse
+            ? (string) $this->psrResponse->getStatusCode()
+            : (string) $this->staticResource->getStatus();
+    }
+
+    /**
+     * Remote user if the request was authenticated. (%u)
+     */
+    public function getRemoteUser() : string
+    {
+        return $this->getServerParam('REMOTE_USER');
+    }
+
+    /**
+     * The URL path requested, not including any query string. (%U)
+     */
+    public function getPath() : string
+    {
+        return $this->getServerParam('PATH_INFO');
+    }
+
+    /**
+     * The canonical ServerName of the server serving the request. (%v)
+     */
+    public function getHost() : string
+    {
+        return $this->getRequestHeader('host');
+    }
+
+    /**
+     * The server name according to the UseCanonicalName setting. (%V)
+     */
+    public function getServerName() : string
+    {
+        return gethostname();
+    }
+
+    /**
+     * First line of request. (%r)
+     */
+    public function getRequestLine() : string
+    {
+        return sprintf(
+            '%s %s%s %s',
+            $this->getMethod(),
+            $this->getPath(),
+            $this->getQuery(),
+            $this->getProtocol()
+        );
+    }
+
+    /**
+     * Returns the response status line
+     */
+    public function getResponseLine() : string
+    {
+        $reasonPhrase = '';
+        if ($this->psrResponse && $this->psrResponse->getReasonPhrase()) {
+            $reasonPhrase .= sprintf(' %s', $this->psrResponse->getReasonPhrase());
+        }
+        return sprintf(
+            '%s %d%s',
+            $this->getProtocol(),
+            $this->getStatus(),
+            $reasonPhrase
+        );
+    }
+
+    /**
+     * Bytes transferred (received and sent), including request and headers (%S)
+     */
+    public function getTransferredSize() : string
+    {
+        return (string) ($this->getRequestMessageSize(0) + $this->getResponseMessageSize(0)) ?: '-';
+    }
+
+    /**
+     * Get the request message size (including first line and headers)
+     */
+    public function getRequestMessageSize($default = null) : ?int
+    {
+        $strlen = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
+
+        $bodySize = $strlen($this->request->rawContent());
+
+        if (null === $bodySize) {
+            return $default;
+        }
+
+        $firstLine = $this->getRequestLine();
+
+        $headers = [];
+
+        foreach ($this->request->header as $header => $value) {
+            if (is_string($value)) {
+                $headers[] = sprintf('%s: %s', $header, $value);
+                continue;
+            }
+
+            foreach ($value as $line) {
+                $headers[] = sprintf('%s: %s', $header, $line);
+            }
+        }
+
+        $headersSize = $strlen(implode("\r\n", $headers));
+
+        return $strlen($firstLine) + 2 + $headersSize + 4 + $bodySize;
+    }
+
+    /**
+     * Get the response message size (including first line and headers)
+     */
+    public function getResponseMessageSize($default = null) : ?int
+    {
+        $bodySize = $this->psrResponse
+            ? $this->psrResponse->getBody()->getSize()
+            : $this->staticResource->getContentLength();
+
+        if (null === $bodySize) {
+            return $default;
+        }
+
+        $strlen = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
+        $firstLineSize = $strlen($this->getResponseLine($message));
+
+        $headerSize = $this->psrResponse
+            ? $this->getPsrResponseHeaderSize()
+            : $this->staticResource->getHeaderSize();
+
+        return $firstLineSize + 2 + $headerSize + 4 + $bodySize;
+    }
+
+    /**
+     * Returns the request time (%t, %{format}t)
+     */
+    public function getRequestTime(string $format) : string
+    {
+        $begin = $this->getServerParam('request_time_float');
+        $time = $begin;
+
+        if (strpos($format, 'begin:') === 0) {
+            $format = substr($format, 6);
+        } elseif (strpos($format, 'end:') === 0) {
+            $time = $this->endTime;
+            $format = substr($format, 4);
+        }
+
+        switch ($format) {
+            case 'sec':
+                return sprintf('[%s]', round($time));
+            case 'msec':
+                return sprintf('[%s]', round($time * 1E3));
+            case 'usec':
+                return sprintf('[%s]', round($time * 1E6));
+            default:
+                return sprintf('[%s]', strftime($format, (int) $time));
+        }
+    }
+
+    /**
+     * The time taken to serve the request. (%T, %{format}T)
+     */
+    public function getRequestDuration(string $format) : string
+    {
+        $begin = $this->getServerParam('request_time_float');
+        switch ($format) {
+            case 'us':
+                return (string) round(($this->endTime - $begin) * 1E6);
+            case 'ms':
+                return (string) round(($this->endTime - $begin) * 1E3);
+            default:
+                return (string) round($this->endTime - $begin);
+        }
+    }
+
+    private function __construct(SwooleHttpRequest $request, bool $useHostnameLookups)
+    {
+        $this->endTime = microtime(true);
+        $this->request = $request;
+        $this->useHostnameLookups = $useHostnameLookups;
+    }
+
+    /**
+     * Returns an server parameter value
+     */
+    private function getServerParam(string $key, string $default = '-') : string
+    {
+        return $this->request->server[strtolower($key)] ?? $default;
+    }
+
+    /**
+     * Returns an ip from the server params
+     */
+    private function getServerParamIp(string $key) : string
+    {
+        $ip = $this->getServerParam($key);
+
+        return false === filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4 | FILTER_FLAG_IPV6)
+            ? '-'
+            : $ip;
+    }
+
+    private function getPsrResponseHeaderSize() : int
+    {
+        if (! $this->psrResponse) {
+            return 0;
+        }
+
+        $headers = [];
+
+        foreach ($this->psrResponse->getHeaders() as $header => $values) {
+            foreach ($values as $value) {
+                $headers[] = sprintf('%s: %s', $header, $value);
+            }
+        }
+
+        $strlen = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
+        return $strlen(implode("\r\n", $headers));
+    }
+}

--- a/src/Log/AccessLogFactory.php
+++ b/src/Log/AccessLogFactory.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Create and return an access logger.
+ *
+ * Uses the Psr\Log\LoggerInterface to seed a Psr3AccessLogDecorator instance,
+ * falling back to the shipped StdoutLogger if none is present. Additionally,
+ * it will look for and use the following configuration, if found:
+ *
+ * <code>
+ * 'zend-expressive-swoole' => [
+ *     'swoole-http-server' => [
+ *         'logger' => [
+ *             'format' => string, // one of the AccessLogFormatter::FORMAT_* constants
+ *             'use-hostname-lookups' => bool, // Set to true to enable hostname lookups
+ *         ],
+ *     ],
+ * ],
+ * </code>
+ */
+class AccessLogFactory
+{
+    public function __invoke(ContainerInterface $container) : AccessLogInterface
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $config = $config['zend-expressive-swoole']['swoole-http-server']['logger'] ?? [];
+
+        return new Psr3AccessLogDecorator(
+            $container->has(LoggerInterface::class) ? $container->get(LoggerInterface::class) : new StdoutLogger(),
+            $this->getFormatter($container, $config),
+            $config['use-hostname-lookups'] ?? false
+        );
+    }
+
+    private function getFormatter(ContainerInterface $container, array $config) : AccessLogFormatterInterface
+    {
+        if ($container->has(AccessLogFormatterInterface::class)) {
+            return $container->get(AccessLogFormatterInterface::class);
+        }
+
+        return new AccessLogFormatter(
+            $config['format'] ?? AccessLogFormatter::FORMAT_COMMON
+        );
+    }
+}

--- a/src/Log/AccessLogFormatter.php
+++ b/src/Log/AccessLogFormatter.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ *
+ * Parts of this class are derived from middlewares/access-log:
+ * @copyright Copyright (c) 2018 Oscar Otero (https://github.com/middlewares/access-log/blob/master/LICENSE)
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+use function preg_replace_callback;
+
+class AccessLogFormatter implements AccessLogFormatterInterface
+{
+    /**
+     * @link http://httpd.apache.org/docs/2.4/mod/mod_log_config.html#examples
+     */
+    public const FORMAT_COMMON = '%h %l %u %t "%r" %>s %b';
+    public const FORMAT_COMMON_VHOST = '%v %h %l %u %t "%r" %>s %b';
+    public const FORMAT_COMBINED = '%h %l %u %t "%r" %>s %b "%{Referer}i" "%{User-Agent}i"';
+    public const FORMAT_REFERER = '%{Referer}i -> %U';
+    public const FORMAT_AGENT = '%{User-Agent}i';
+
+    /**
+     * @link https://httpd.apache.org/docs/2.4/logs.html#virtualhost
+     */
+    public const FORMAT_VHOST = '%v %l %u %t "%r" %>s %b';
+
+    /**
+     * @link https://anonscm.debian.org/cgit/pkg-apache/apache2.git/tree/debian/config-dir/apache2.conf.in#n212
+     * @codingStandardsIgnoreStart
+     * phpcs:disable
+     */
+    public const FORMAT_COMMON_DEBIAN = '%h %l %u %t “%r” %>s %O';
+    public const FORMAT_COMBINED_DEBIAN = '%h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i”';
+    public const FORMAT_VHOST_COMBINED_DEBIAN = '%v:%p %h %l %u %t “%r” %>s %O “%{Referer}i” “%{User-Agent}i"';
+    // @codingStandardsIgnoreEnd
+    // phpcs:enable
+
+    /**
+     * Message format to use when generating a log message.
+     *
+     * @var string
+     */
+    private $format;
+
+    public function __construct(string $format = self::FORMAT_COMMON)
+    {
+        $this->format = $format;
+    }
+
+    /**
+     * Transform a log format to the final string to log.
+     */
+    public function format(AccessLogDataMap $map) : string
+    {
+        $message = $this->replaceConstantDirectives($this->format, $map);
+        $message = $this->replaceVariableDirectives($message, $map);
+        return $message;
+    }
+
+    private function replaceConstantDirectives(
+        string $format,
+        AccessLogDataMap $map
+    ) : string {
+        return preg_replace_callback(
+            '/%(?:[<>])?([%aABbDfhHklLmpPqrRstTuUvVXIOS])/',
+            function (array $matches) use ($map) {
+                switch ($matches[1]) {
+                    case '%':
+                        return '%';
+                    case 'a':
+                        return $map->getClientIp();
+                    case 'A':
+                        return $map->getLocalIp();
+                    case 'B':
+                        return $map->getBodySize('0');
+                    case 'b':
+                        return $map->getBodySize('-');
+                    case 'D':
+                        return $map->getRequestDuration('ms');
+                    case 'f':
+                        return $map->getFilename();
+                    case 'h':
+                        return $map->getRemoteHostname();
+                    case 'H':
+                        return $map->getProtocol();
+                    case 'm':
+                        return $map->getMethod();
+                    case 'p':
+                        return $map->getPort('canonical');
+                    case 'q':
+                        return $map->getQuery();
+                    case 'r':
+                        return $map->getRequestLine();
+                    case 's':
+                        return $map->getStatus();
+                    case 't':
+                        return $map->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z');
+                    case 'T':
+                        return $map->getRequestDuration('s');
+                    case 'u':
+                        return $map->getRemoteUser();
+                    case 'U':
+                        return $map->getPath();
+                    case 'v':
+                        return $map->getHost();
+                    case 'V':
+                        return $map->getServerName();
+                    case 'I':
+                        return $map->getRequestMessageSize('-');
+                    case 'O':
+                        return $map->getResponseMessageSize('-');
+                    case 'S':
+                        return $map->getTransferredSize();
+                    //NOT IMPLEMENTED
+                    case 'k':
+                    case 'l':
+                    case 'L':
+                    case 'P':
+                    case 'R':
+                    case 'X':
+                    default:
+                        return '-';
+                }
+            },
+            $format
+        );
+    }
+
+    private function replaceVariableDirectives(
+        string $format,
+        AccessLogDataMap $map
+    ): string {
+        return preg_replace_callback(
+            '/%(?:[<>])?{([^}]+)}([aCeinopPtT])/',
+            function (array $matches) use ($map) {
+                switch ($matches[2]) {
+                    case 'a':
+                        return $map->getClientIp();
+                    case 'C':
+                        return $map->getCookie($matches[1]);
+                    case 'e':
+                        return $map->getEnv($matches[1]);
+                    case 'i':
+                        return $map->getRequestHeader($matches[1]);
+                    case 'o':
+                        return $map->getResponseHeader($matches[1]);
+                    case 'p':
+                        return $map->getPort($matches[1]);
+                    case 't':
+                        return $map->getRequestTime($matches[1]);
+                    case 'T':
+                        return $map->getRequestDuration($matches[1]);
+                    //NOT IMPLEMENTED
+                    case 'n':
+                    case 'P':
+                    default:
+                        return '-';
+                }
+            },
+            $format
+        );
+    }
+}

--- a/src/Log/AccessLogFormatterInterface.php
+++ b/src/Log/AccessLogFormatterInterface.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+interface AccessLogFormatterInterface
+{
+    public function format(AccessLogDataMap $map) : string;
+}

--- a/src/Log/AccessLogInterface.php
+++ b/src/Log/AccessLogInterface.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-logger for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-logger/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Swoole\Http\Request;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+
+interface AccessLogInterface extends LoggerInterface
+{
+    public function logAccessForStaticResource(Request $request, StaticResourceResponse $response) : void;
+
+    public function logAccessForPsr7Resource(Request $request, ResponseInterface $response) : void;
+}

--- a/src/Log/Psr3AccessLogDecorator.php
+++ b/src/Log/Psr3AccessLogDecorator.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Log;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
+use Swoole\Http\Request;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+
+class Psr3AccessLogDecorator implements AccessLogInterface
+{
+    /**
+     * @var AccessLogFormatter
+     */
+    private $formatter;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * Whether or not to look up remote host names when preparing the access
+     * log message
+     *
+     * @var bool
+     */
+    private $useHostnameLookups;
+
+    public function __construct(
+        LoggerInterface $logger,
+        AccessLogFormatterInterface $formatter,
+        bool $useHostnameLookups = false
+    ) {
+        $this->logger = $logger;
+        $this->formatter = $formatter;
+        $this->useHostnameLookups = $useHostnameLookups;
+    }
+
+    public function logAccessForStaticResource(Request $request, StaticResourceResponse $response) : void
+    {
+        $message = $this->formatter->format(
+            AccessLogDataMap::createWithStaticResource($request, $response, $this->useHostnameLookups)
+        );
+        $response->getStatus() >= 400
+            ? $this->logger->error($message)
+            : $this->logger->info($message);
+    }
+
+    public function logAccessForPsr7Resource(Request $request, ResponseInterface $response) : void
+    {
+        $message = $this->formatter->format(
+            AccessLogDataMap::createWithPsrResponse($request, $response, $this->useHostnameLookups)
+        );
+        $response->getStatusCode() >= 400
+            ? $this->logger->error($message)
+            : $this->logger->info($message);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function emergency($message, array $context = [])
+    {
+        $this->logger->emergency($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->logger->alert($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->logger->critical($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function error($message, array $context = [])
+    {
+        $this->logger->error($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->logger->warning($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->logger->notice($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function info($message, array $context = [])
+    {
+        $this->logger->info($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->logger->debug($message, $context);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->logger->log($level, $message, $context);
+    }
+}

--- a/src/Log/StdoutLogger.php
+++ b/src/Log/StdoutLogger.php
@@ -7,7 +7,7 @@
 
 declare(strict_types=1);
 
-namespace Zend\Expressive\Swoole;
+namespace Zend\Expressive\Swoole\Log;
 
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;

--- a/src/StaticResourceHandler.php
+++ b/src/StaticResourceHandler.php
@@ -12,89 +12,11 @@ namespace Zend\Expressive\Swoole;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
 
-use function file_exists;
 use function is_callable;
 use function is_dir;
-use function pathinfo;
-
-use const PATHINFO_EXTENSION;
 
 class StaticResourceHandler implements StaticResourceHandlerInterface
 {
-    /**
-     * Default static file extensions supported
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
-     */
-    public const TYPE_MAP_DEFAULT = [
-        '7z'    => 'application/x-7z-compressed',
-        'aac'   => 'audio/aac',
-        'arc'   => 'application/octet-stream',
-        'avi'   => 'video/x-msvideo',
-        'azw'   => 'application/vnd.amazon.ebook',
-        'bin'   => 'application/octet-stream',
-        'bmp'   => 'image/bmp',
-        'bz'    => 'application/x-bzip',
-        'bz2'   => 'application/x-bzip2',
-        'css'   => 'text/css',
-        'csv'   => 'text/csv',
-        'doc'   => 'application/msword',
-        'docx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'eot'   => 'application/vnd.ms-fontobject',
-        'epub'  => 'application/epub+zip',
-        'es'    => 'application/ecmascript',
-        'gif'   => 'image/gif',
-        'htm'   => 'text/html',
-        'html'  => 'text/html',
-        'ico'   => 'image/x-icon',
-        'jpg'   => 'image/jpg',
-        'jpeg'  => 'image/jpg',
-        'js'    => 'text/javascript',
-        'json'  => 'application/json',
-        'mp4'   => 'video/mp4',
-        'mpeg'  => 'video/mpeg',
-        'odp'   => 'application/vnd.oasis.opendocument.presentation',
-        'ods'   => 'application/vnd.oasis.opendocument.spreadsheet',
-        'odt'   => 'application/vnd.oasis.opendocument.text',
-        'oga'   => 'audio/ogg',
-        'ogv'   => 'video/ogg',
-        'ogx'   => 'application/ogg',
-        'otf'   => 'font/otf',
-        'pdf'   => 'application/pdf',
-        'png'   => 'image/png',
-        'ppt'   => 'application/vnd.ms-powerpoint',
-        'pptx'  => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-        'rar'   => 'application/x-rar-compressed',
-        'rtf'   => 'application/rtf',
-        'svg'   => 'image/svg+xml',
-        'swf'   => 'application/x-shockwave-flash',
-        'tar'   => 'application/x-tar',
-        'tif'   => 'image/tiff',
-        'tiff'  => 'image/tiff',
-        'ts'    => 'application/typescript',
-        'ttf'   => 'font/ttf',
-        'txt'   => 'text/plain',
-        'wav'   => 'audio/wav',
-        'weba'  => 'audio/webm',
-        'webm'  => 'video/webm',
-        'webp'  => 'image/webp',
-        'woff'  => 'font/woff',
-        'woff2' => 'font/woff2',
-        'xhtml' => 'application/xhtml+xml',
-        'xls'   => 'application/vnd.ms-excel',
-        'xlsx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        'xml'   => 'application/xml',
-        'xul'   => 'application/vnd.mozilla.xul+xml',
-        'zip'   => 'application/zip',
-    ];
-
-    /**
-     * Cache the file extensions (type) for valid static file
-     *
-     * @var array
-     */
-    private $cacheTypeFile = [];
-
     /**
      * @var string
      */
@@ -108,18 +30,12 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
     private $middleware;
 
     /**
-     * @var array[string, string] Extension => mimetype map
-     */
-    private $typeMap;
-
-    /**
      * @throws Exception\InvalidStaticResourceMiddlewareException for any
      *     non-callable middleware encountered.
      */
     public function __construct(
         string $docRoot,
-        array $middleware = [],
-        array $typeMap = null
+        array $middleware = []
     ) {
         if (! is_dir($docRoot)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -131,29 +47,22 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
 
         $this->docRoot = $docRoot;
         $this->middleware = $middleware;
-        $this->typeMap = null === $typeMap ? self::TYPE_MAP_DEFAULT : $typeMap;
     }
 
-    public function isStaticResource(SwooleHttpRequest $request) : bool
-    {
-        $staticFile = $this->docRoot . $request->server['request_uri'];
-        return isset($this->cacheTypeFile[$staticFile]) || $this->cacheFile($staticFile);
-    }
-
-    public function sendStaticResource(SwooleHttpRequest $request, SwooleHttpResponse $response) : void
-    {
-        $server   = $request->server;
-        $filename = $this->docRoot . $server['request_uri'];
-        if (! isset($this->cacheTypeFile[$filename])) {
-            // fail-safe, in case isStaticResource() was not called first
-            return;
-        }
-
-        $response->header('Content-Type', $this->cacheTypeFile[$filename], true);
+    public function processStaticResource(
+        SwooleHttpRequest $request,
+        SwooleHttpResponse $response
+    ) : ?StaticResourceHandler\StaticResourceResponse {
+        $filename = $this->docRoot . $request->server['request_uri'];
 
         $middleware = new StaticResourceHandler\MiddlewareQueue($this->middleware);
         $staticResourceResponse = $middleware($request, $filename);
+        if ($staticResourceResponse->isFailure()) {
+            return null;
+        }
+
         $staticResourceResponse->sendSwooleResponse($response, $filename);
+        return $staticResourceResponse;
     }
 
     /**
@@ -172,23 +81,5 @@ class StaticResourceHandler implements StaticResourceHandlerInterface
                 );
             }
         }
-    }
-
-    /**
-     * Attempt to cache a static file resource.
-     */
-    private function cacheFile(string $fileName) : bool
-    {
-        $type = pathinfo($fileName, PATHINFO_EXTENSION);
-        if (! isset($this->typeMap[$type])) {
-            return false;
-        }
-
-        if (! file_exists($fileName)) {
-            return false;
-        }
-
-        $this->cacheTypeFile[$fileName] = $this->typeMap[$type];
-        return true;
     }
 }

--- a/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
+++ b/src/StaticResourceHandler/ContentTypeFilterMiddleware.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\StaticResourceHandler;
+
+use Swoole\Http\Request;
+
+use function file_exists;
+use function pathinfo;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * Filter by content type
+ *
+ * This middleware uses a map of file extensions to content types. If the
+ * requested file has an extension that is not in the list, the middleware
+ * returns a failure response.
+ *
+ * Otherwise, it caches the discovered content-type for the requested file,
+ * and emits a Content-Type header on the final response.
+ *
+ * This middleware should likely execute early in the chain.
+ */
+class ContentTypeFilterMiddleware implements MiddlewareInterface
+{
+    /**
+     * Default static file extensions supported
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types
+     */
+    public const TYPE_MAP_DEFAULT = [
+        '7z'    => 'application/x-7z-compressed',
+        'aac'   => 'audio/aac',
+        'arc'   => 'application/octet-stream',
+        'avi'   => 'video/x-msvideo',
+        'azw'   => 'application/vnd.amazon.ebook',
+        'bin'   => 'application/octet-stream',
+        'bmp'   => 'image/bmp',
+        'bz'    => 'application/x-bzip',
+        'bz2'   => 'application/x-bzip2',
+        'css'   => 'text/css',
+        'csv'   => 'text/csv',
+        'doc'   => 'application/msword',
+        'docx'  => 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+        'eot'   => 'application/vnd.ms-fontobject',
+        'epub'  => 'application/epub+zip',
+        'es'    => 'application/ecmascript',
+        'gif'   => 'image/gif',
+        'htm'   => 'text/html',
+        'html'  => 'text/html',
+        'ico'   => 'image/x-icon',
+        'jpg'   => 'image/jpg',
+        'jpeg'  => 'image/jpg',
+        'js'    => 'text/javascript',
+        'json'  => 'application/json',
+        'mp4'   => 'video/mp4',
+        'mpeg'  => 'video/mpeg',
+        'odp'   => 'application/vnd.oasis.opendocument.presentation',
+        'ods'   => 'application/vnd.oasis.opendocument.spreadsheet',
+        'odt'   => 'application/vnd.oasis.opendocument.text',
+        'oga'   => 'audio/ogg',
+        'ogv'   => 'video/ogg',
+        'ogx'   => 'application/ogg',
+        'otf'   => 'font/otf',
+        'pdf'   => 'application/pdf',
+        'png'   => 'image/png',
+        'ppt'   => 'application/vnd.ms-powerpoint',
+        'pptx'  => 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+        'rar'   => 'application/x-rar-compressed',
+        'rtf'   => 'application/rtf',
+        'svg'   => 'image/svg+xml',
+        'swf'   => 'application/x-shockwave-flash',
+        'tar'   => 'application/x-tar',
+        'tif'   => 'image/tiff',
+        'tiff'  => 'image/tiff',
+        'ts'    => 'application/typescript',
+        'ttf'   => 'font/ttf',
+        'txt'   => 'text/plain',
+        'wav'   => 'audio/wav',
+        'weba'  => 'audio/webm',
+        'webm'  => 'video/webm',
+        'webp'  => 'image/webp',
+        'woff'  => 'font/woff',
+        'woff2' => 'font/woff2',
+        'xhtml' => 'application/xhtml+xml',
+        'xls'   => 'application/vnd.ms-excel',
+        'xlsx'  => 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        'xml'   => 'application/xml',
+        'xul'   => 'application/vnd.mozilla.xul+xml',
+        'zip'   => 'application/zip',
+    ];
+
+    /**
+     * Cache the file extensions (type) for valid static file
+     *
+     * @var array
+     */
+    private $cacheTypeFile = [];
+
+    /**
+     * @var array[string, string] Extension => mimetype map
+     */
+    private $typeMap;
+
+    /**
+     * @param null|array[string, string] $typeMap Map of extensions to Content-Type
+     *     values. If `null` is provided, the default list in TYPE_MAP_DEFAULT will
+     *     be used. Otherwise, the list provided is used verbatim.
+     */
+    public function __construct(array $typeMap = null)
+    {
+        $this->typeMap = null === $typeMap ? self::TYPE_MAP_DEFAULT : $typeMap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(Request $request, string $filename, callable $next): StaticResourceResponse
+    {
+        if (! isset($this->cacheTypeFile[$filename])
+            && ! $this->cacheFile($filename)
+        ) {
+            $response = new StaticResourceResponse();
+            $response->markAsFailure();
+            return $response;
+        }
+
+        $response = $next($request, $filename);
+        $response->addHeader('Content-Type', $this->cacheTypeFile[$filename]);
+        return $response;
+    }
+
+    /**
+     * Attempt to cache a static file resource.
+     */
+    private function cacheFile(string $fileName) : bool
+    {
+        $type = pathinfo($fileName, PATHINFO_EXTENSION);
+        if (! isset($this->typeMap[$type])) {
+            return false;
+        }
+
+        if (! file_exists($fileName)) {
+            return false;
+        }
+
+        $this->cacheTypeFile[$fileName] = $this->typeMap[$type];
+        return true;
+    }
+}

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -49,6 +49,8 @@ class StaticResourceResponse
         $this->sendContent = $sendContent;
         $this->responseContentCallback = $responseContentCallback
             ?: function (SwooleHttpResponse $response, string $filename) : void {
+                // Lower-case is used here for consistency with requests; aids with logging
+                $response->header('content-length', (string) filesize($filename), true);
                 $response->sendfile($filename);
             };
     }

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -12,6 +12,9 @@ namespace Zend\Expressive\Swoole\StaticResourceHandler;
 use Swoole\Http\Response as SwooleHttpResponse;
 
 use function filesize;
+use function function_exists;
+use function implode;
+use function sprintf;
 
 class StaticResourceResponse
 {
@@ -86,6 +89,33 @@ class StaticResourceResponse
     public function disableContent() : void
     {
         $this->sendContent = false;
+    }
+
+    /**
+     * Retrieve a single named header
+     *
+     * This is exposed to allow logging specific response headers when present.
+     */
+    public function getHeader(string $name) : string
+    {
+        return $this->headers[$name] ?? '';
+    }
+
+    /**
+     * Retrieve the aggregated length of all headers.
+     *
+     * This is exposed for logging purposes.
+     */
+    public function getHeaderSize() : int
+    {
+        $headers = [];
+        foreach ($this->headers as $header => $value) {
+            $headers[] = sprintf('%s: %s', $header, $value);
+        }
+
+        $strlen = function_exists('mb_strlen') ? 'mb_strlen' : 'strlen';
+
+        return $strlen(implode("\r\n", $headers));
     }
 
     /**

--- a/src/StaticResourceHandler/StaticResourceResponse.php
+++ b/src/StaticResourceHandler/StaticResourceResponse.php
@@ -11,12 +11,25 @@ namespace Zend\Expressive\Swoole\StaticResourceHandler;
 
 use Swoole\Http\Response as SwooleHttpResponse;
 
+use function filesize;
+
 class StaticResourceResponse
 {
+    /**
+     * @var int
+     */
+    private $contentLength = 0;
+
     /**
      * @var array[string, string]
      */
     private $headers = [];
+
+    /**
+     * @var bool Does this response represent a failure to locate the requested
+     *     resource and/or that it cannot be requested?
+     */
+    private $isFailure = false;
 
     /**
      * @var callable
@@ -49,8 +62,8 @@ class StaticResourceResponse
         $this->sendContent = $sendContent;
         $this->responseContentCallback = $responseContentCallback
             ?: function (SwooleHttpResponse $response, string $filename) : void {
-                // Lower-case is used here for consistency with requests; aids with logging
-                $response->header('content-length', (string) filesize($filename), true);
+                $this->contentLength = filesize($filename);
+                $response->header('Content-Length', $this->contentLength, true);
                 $response->sendfile($filename);
             };
     }
@@ -60,9 +73,48 @@ class StaticResourceResponse
         $this->headers[$name] = $value;
     }
 
+    /**
+     * Retrieve the content length that was sent via sendSwooleResponse()
+     *
+     * This is exposed to allow logging the content emitted.
+     */
+    public function getContentLength() : int
+    {
+        return $this->contentLength;
+    }
+
     public function disableContent() : void
     {
         $this->sendContent = false;
+    }
+
+    /**
+     * Retrieve the response status code that was sent via sendSwooleResponse()
+     *
+     * This is exposed to allow logging the status code emitted.
+     */
+    public function getStatus() : int
+    {
+        return $this->status;
+    }
+
+    /**
+     * Can the requested resource be served?
+     */
+    public function isFailure() : bool
+    {
+        return $this->isFailure;
+    }
+
+    /**
+     * Indicate that the requested resource cannot be served.
+     *
+     * Call this method if the requested resource does not exist, or if it
+     * fails certain validation checks.
+     */
+    public function markAsFailure() : void
+    {
+        $this->isFailure = true;
     }
 
     /**
@@ -84,6 +136,11 @@ class StaticResourceResponse
         $contentSender = $this->responseContentCallback;
 
         $this->sendContent ? $contentSender($response, $filename) : $response->end();
+    }
+
+    public function setContentLength(int $length) : void
+    {
+        $this->contentLength = $length;
     }
 
     /**

--- a/src/StaticResourceHandlerFactory.php
+++ b/src/StaticResourceHandlerFactory.php
@@ -72,8 +72,7 @@ class StaticResourceHandlerFactory
 
         return new StaticResourceHandler(
             $config['document-root'] ?? getcwd() . '/public',
-            $this->configureMiddleware($config),
-            $config['type-map'] ?? StaticResourceHandler::TYPE_MAP_DEFAULT
+            $this->configureMiddleware($config)
         );
     }
 
@@ -107,6 +106,9 @@ class StaticResourceHandlerFactory
     protected function configureMiddleware(array $config) : array
     {
         $middleware = [
+            new StaticResourceHandler\ContentTypeFilterMiddleware(
+                $config['type-map'] ?? StaticResourceHandler\ContentTypeFilterMiddleware::TYPE_MAP_DEFAULT
+            ),
             new StaticResourceHandler\MethodNotAllowedMiddleware(),
             new StaticResourceHandler\OptionsMiddleware(),
             new StaticResourceHandler\HeadMiddleware(),

--- a/src/StaticResourceHandlerInterface.php
+++ b/src/StaticResourceHandlerInterface.php
@@ -15,12 +15,15 @@ use Swoole\Http\Response as SwooleHttpResponse;
 interface StaticResourceHandlerInterface
 {
     /**
-     * Does the request match to a static resource?
+     * Attempt to process a static resource based on the current request.
+     *
+     * If the resource cannot be processed, the method should return null.
+     * Otherwise, it should return the StaticResourceResponse that was used
+     * to send the Swoole response instance. The runner can then query this
+     * for content length and status.
      */
-    public function isStaticResource(SwooleHttpRequest $request) : bool;
-
-    /**
-     * Send the static resource based on the current request.
-     */
-    public function sendStaticResource(SwooleHttpRequest $request, SwooleHttpResponse $response) : void;
+    public function processStaticResource(
+        SwooleHttpRequest $request,
+        SwooleHttpResponse $response
+    ) : ?StaticResourceHandler\StaticResourceResponse;
 }

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -308,10 +308,11 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
             'request_uri'    => $request->server['request_uri']
         ]);
 
-        if ($this->staticResourceHandler
-            && $this->staticResourceHandler->isStaticResource($request)
-        ) {
-            $this->staticResourceHandler->sendStaticResource($request, $response);
+        $staticResourceResponse = $this->staticResourceHandler
+            ? $this->staticResourceHandler->processStaticResource($request, $response)
+            : null;
+        if ($staticResourceResponse) {
+            // Eventually: move logging here
             return;
         }
 

--- a/src/SwooleRequestHandlerRunnerFactory.php
+++ b/src/SwooleRequestHandlerRunnerFactory.php
@@ -11,7 +11,6 @@ namespace Zend\Expressive\Swoole;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
-use Psr\Log\LoggerInterface;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
 
@@ -22,8 +21,8 @@ class SwooleRequestHandlerRunnerFactory
         $staticResourceHandler = $container->has(StaticResourceHandlerInterface::class)
             ? $container->get(StaticResourceHandlerInterface::class)
             : null;
-        $logger = $container->has(LoggerInterface::class)
-            ? $container->get(LoggerInterface::class)
+        $logger = $container->has(Log\AccessLogInterface::class)
+            ? $container->get(Log\AccessLogInterface::class)
             : null;
 
         return new SwooleRequestHandlerRunner(

--- a/test/Log/AccessLogFactoryTest.php
+++ b/test/Log/AccessLogFactoryTest.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Log;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use ReflectionProperty;
+use Zend\Expressive\Swoole\Log\AccessLogFactory;
+use Zend\Expressive\Swoole\Log\AccessLogFormatter;
+use Zend\Expressive\Swoole\Log\AccessLogFormatterInterface;
+use Zend\Expressive\Swoole\Log\Psr3AccessLogDecorator;
+use Zend\Expressive\Swoole\Log\StdoutLogger;
+
+class AccessLogFactoryTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->container = $this->prophesize(ContainerInterface::class);
+        $this->logger = $this->prophesize(LoggerInterface::class)->reveal();
+        $this->formatter = $this->prophesize(AccessLogFormatterInterface::class)->reveal();
+    }
+
+    public function testCreatesDecoratorWithStdoutLoggerAndAccessLogFormatterWhenNoConfigLoggerOrFormatterPresent()
+    {
+        $factory = new AccessLogFactory();
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->get('config')->shouldNotBeCalled();
+        $this->container->has(LoggerInterface::class)->willReturn(false);
+        $this->container->get(LoggerInterface::class)->shouldNotBeCalled();
+        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
+        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
+
+        $logger = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
+        $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);
+        $this->assertAttributeInstanceOf(AccessLogFormatter::class, 'formatter', $logger);
+    }
+
+    public function testUsesConfiguredLoggerServiceWhenPresent()
+    {
+        $factory = new AccessLogFactory();
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->get('config')->shouldNotBeCalled();
+        $this->container->has(LoggerInterface::class)->willReturn(true);
+        $this->container->get(LoggerInterface::class)->willReturn($this->logger);
+        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
+        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
+
+        $logger = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
+        $this->assertAttributeSame($this->logger, 'logger', $logger);
+        $this->assertAttributeInstanceOf(AccessLogFormatter::class, 'formatter', $logger);
+    }
+
+    public function testUsesConfiguredFormatterServiceWhenPresent()
+    {
+        $factory = new AccessLogFactory();
+
+        $this->container->has('config')->willReturn(false);
+        $this->container->get('config')->shouldNotBeCalled();
+        $this->container->has(LoggerInterface::class)->willReturn(false);
+        $this->container->get(LoggerInterface::class)->shouldNotBeCalled();
+        $this->container->has(AccessLogFormatterInterface::class)->willReturn(true);
+        $this->container->get(AccessLogFormatterInterface::class)->willReturn($this->formatter);
+
+        $logger = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
+        $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);
+        $this->assertAttributeSame($this->formatter, 'formatter', $logger);
+    }
+
+    public function testUsesConfigurationToSeedGeneratedLoggerAndFormatter()
+    {
+        $factory = new AccessLogFactory();
+
+        $this->container->has('config')->willReturn(true);
+        $this->container->get('config')->willReturn([
+            'zend-expressive-swoole' => [
+                'swoole-http-server' => [
+                    'logger' => [
+                        'format' => AccessLogFormatter::FORMAT_COMBINED,
+                        'use-hostname-lookups' => true,
+                    ],
+                ],
+            ],
+        ]);
+        $this->container->has(LoggerInterface::class)->willReturn(false);
+        $this->container->get(LoggerInterface::class)->shouldNotBeCalled();
+        $this->container->has(AccessLogFormatterInterface::class)->willReturn(false);
+        $this->container->get(AccessLogFormatterInterface::class)->shouldNotBeCalled();
+
+        $logger = $factory($this->container->reveal());
+
+        $this->assertInstanceOf(Psr3AccessLogDecorator::class, $logger);
+        $this->assertAttributeInstanceOf(StdoutLogger::class, 'logger', $logger);
+        $this->assertAttributeInstanceOf(AccessLogFormatter::class, 'formatter', $logger);
+        $this->assertAttributeSame(true, 'useHostnameLookups', $logger);
+
+        $r = new ReflectionProperty($logger, 'formatter');
+        $r->setAccessible(true);
+        $formatter = $r->getValue($logger);
+
+        $this->assertAttributeSame(AccessLogFormatter::FORMAT_COMBINED, 'format', $formatter);
+    }
+}

--- a/test/Log/AccessLogFormatterTest.php
+++ b/test/Log/AccessLogFormatterTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Log;
+
+use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Swoole\Log\AccessLogDataMap;
+use Zend\Expressive\Swoole\Log\AccessLogFormatter;
+
+class AccessLogFormatterTest extends TestCase
+{
+    public function testFormatterDelegatesToDataMapToReplacePlaceholdersInFormat()
+    {
+        $hostname = gethostname();
+
+        $dataMap = $this->prophesize(AccessLogDataMap::class);
+        $dataMap->getClientIp()->willReturn('127.0.0.10'); // %a
+        $dataMap->getLocalIp()->willReturn('127.0.0.1'); // %A
+        $dataMap->getBodySize('0')->willReturn('1234'); // %B
+        $dataMap->getBodySize('-')->willReturn('1234'); // %b
+        $dataMap->getRequestDuration('ms')->willReturn('4321'); // %D
+        $dataMap->getFilename()->willReturn(__FILE__); // %f
+        $dataMap->getRemoteHostname()->willReturn($hostname); // %h
+        $dataMap->getProtocol()->willReturn('HTTP/1.1'); // %H
+        $dataMap->getMethod()->willReturn('POST'); // %m
+        $dataMap->getPort('canonical')->willReturn('9000'); // %p
+        $dataMap->getQuery()->willReturn('?foo=bar'); // %q
+        $dataMap->getRequestLine()->willReturn('POST /path?foo=bar HTTP/1.1'); // %r
+        $dataMap->getStatus()->willReturn('202'); // %s
+        $dataMap->getRequestTime('begin:%d/%b/%Y:%H:%M:%S %z')->willReturn('[1234567890]'); // %t
+        $dataMap->getRequestDuration('s')->willReturn('22'); // %T
+        $dataMap->getRemoteUser()->willReturn('expressive'); // %u
+        $dataMap->getPath()->willReturn('/path'); // %U
+        $dataMap->getHost()->willReturn('expressive.local'); // %v
+        $dataMap->getServerName()->willReturn('expressive.local'); // %V
+        $dataMap->getRequestMessageSize('-')->willReturn('78'); // %I
+        $dataMap->getResponseMessageSize('-')->willReturn('89'); // %O
+        $dataMap->getTransferredSize()->willReturn('123'); // %S
+        $dataMap->getCookie('cookie_name')->willReturn('chocolate'); // %{cookie_name}C
+        $dataMap->getEnv('env_name')->willReturn('php'); // %{env_name}e
+        $dataMap->getRequestHeader('X-Request-Header')->willReturn('request'); // %{X-Request-Header}i
+        $dataMap->getResponseHeader('X-Response-Header')->willReturn('response'); // %{X-Response-Header}o
+        $dataMap->getPort('local')->willReturn('9999'); // %{local}p
+        $dataMap->getRequestTime('end:sec')->willReturn('[1234567890]'); // %{end:sec}t
+        $dataMap->getRequestDuration('us')->willReturn('22'); // %{us}T
+
+        $format = '%a %A %B %b %D %f %h %H %m %p %q %r %s %t %T %u %U %v %V %I %O %S'
+            . ' %{cookie_name}C %{env_name}e %{X-Request-Header}i %{X-Response-Header}o'
+            . ' %{local}p %{end:sec}t %{us}T';
+        $expected = [
+            '127.0.0.10',
+            '127.0.0.1',
+            '1234',
+            '1234',
+            '4321',
+            __FILE__,
+            $hostname,
+            'HTTP/1.1',
+            'POST',
+            '9000',
+            '?foo=bar',
+            'POST /path?foo=bar HTTP/1.1',
+            '202',
+            '[1234567890]',
+            '22',
+            'expressive',
+            '/path',
+            'expressive.local',
+            'expressive.local',
+            '78',
+            '89',
+            '123',
+            'chocolate',
+            'php',
+            'request',
+            'response',
+            '9999',
+            '[1234567890]',
+            '22',
+        ];
+        $expected = implode(' ', $expected);
+
+        $formatter = new AccessLogFormatter($format);
+
+        $message = $formatter->format($dataMap->reveal());
+
+        $this->assertEquals($expected, $message);
+    }
+}

--- a/test/Log/Psr3AccessLogDecoratorTest.php
+++ b/test/Log/Psr3AccessLogDecoratorTest.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Log;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface as Psr7Response;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use ReflectionClass;
+use ReflectionProperty;
+use Swoole\Http\Request;
+use Zend\Expressive\Swoole\Log\AccessLogDataMap;
+use Zend\Expressive\Swoole\Log\AccessLogFormatterInterface;
+use Zend\Expressive\Swoole\Log\Psr3AccessLogDecorator;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+
+class Psr3AccessLogDecoratorTest extends TestCase
+{
+    public function setUp()
+    {
+        $this->psr3Logger = $this->prophesize(LoggerInterface::class);
+        $this->formatter = $this->prophesize(AccessLogFormatterInterface::class);
+        $this->request = $this->prophesize(Request::class)->reveal();
+        $this->psr7Response = $this->prophesize(Psr7Response::class);
+        $this->staticResponse = $this->prophesize(StaticResourceResponse::class);
+    }
+
+    public function psr3Methods() : iterable
+    {
+        $r = new ReflectionClass(LoggerInterface::class);
+        foreach ($r->getMethods() as $method) {
+            $name = $method->getName();
+            yield $name => [$name];
+        }
+    }
+
+    /**
+     * @dataProvider psr3Methods
+     */
+    public function testProxiesToPsr3Methods(string $method)
+    {
+        $logger = new Psr3AccessLogDecorator($this->psr3Logger->reveal(), $this->formatter->reveal());
+        switch ($method) {
+            case 'log':
+                $this->psr3Logger
+                    ->log(LogLevel::DEBUG, 'message', ['foo' => 'bar'])
+                    ->shouldBeCalled();
+                $this->assertNull($logger->log(LogLevel::DEBUG, 'message', ['foo' => 'bar']));
+                break;
+            default:
+                $this->psr3Logger
+                    ->$method('message', ['foo' => 'bar'])
+                    ->shouldBeCalled();
+                $this->assertNull($logger->$method('message', ['foo' => 'bar']));
+                break;
+        }
+    }
+
+    public function statusLogMethodValues()
+    {
+        return [
+            '100' => [100, 'info'],
+            '200' => [200, 'info'],
+            '302' => [302, 'info'],
+            '400' => [400, 'error'],
+            '500' => [500, 'error'],
+        ];
+    }
+
+    /**
+     * @dataProvider statusLogMethodValues
+     */
+    public function testLogAccessForStaticResourceFormatsMessageAndPassesItToPsr3Logger(
+        int $status,
+        string $logMethod
+    ) {
+        $expected = 'message';
+        $request = $this->request;
+
+        $response = $this->staticResponse;
+        $response->getStatus()->willReturn($status);
+
+        $this->formatter
+            ->format(
+                Argument::that(function ($mapper) use ($request, $response) {
+                    TestCase::assertInstanceOf(AccessLogDataMap::class, $mapper);
+                    TestCase::assertAttributeSame($request, 'request', $mapper);
+                    TestCase::assertAttributeSame($response->reveal(), 'staticResource', $mapper);
+                    TestCase::assertAttributeSame(false, 'useHostnameLookups', $mapper);
+                    return true;
+                })
+            )
+            ->willReturn($expected);
+
+        $this->psr3Logger->$logMethod($expected)->shouldBeCalled();
+
+        $logger = new Psr3AccessLogDecorator($this->psr3Logger->reveal(), $this->formatter->reveal());
+
+        $this->assertNull($logger->logAccessForStaticResource(
+            $this->request,
+            $response->reveal()
+        ));
+    }
+
+    /**
+     * @dataProvider statusLogMethodValues
+     */
+    public function testLogAccessForPsr7ResourceFormatsMessageAndPassesItToPsr3Logger(
+        int $status,
+        string $logMethod
+    ) {
+        $expected = 'message';
+        $request = $this->request;
+
+        $response = $this->psr7Response;
+        $response->getStatusCode()->willReturn($status);
+
+        $this->formatter
+            ->format(
+                Argument::that(function ($mapper) use ($request, $response) {
+                    TestCase::assertInstanceOf(AccessLogDataMap::class, $mapper);
+                    TestCase::assertAttributeSame($request, 'request', $mapper);
+                    TestCase::assertAttributeSame($response->reveal(), 'psrResponse', $mapper);
+                    TestCase::assertAttributeSame(false, 'useHostnameLookups', $mapper);
+                    return true;
+                })
+            )
+            ->willReturn($expected);
+
+        $this->psr3Logger->$logMethod($expected)->shouldBeCalled();
+
+        $logger = new Psr3AccessLogDecorator($this->psr3Logger->reveal(), $this->formatter->reveal());
+
+        $this->assertNull($logger->logAccessForPsr7Resource(
+            $this->request,
+            $response->reveal()
+        ));
+    }
+}

--- a/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
+++ b/test/StaticResourceHandler/ContentTypeFilterMiddlewareTest.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\StaticResourceHandler;
+
+use PHPUnit\Framework\TestCase;
+use Swoole\Http\Request;
+use Zend\Expressive\Swoole\StaticResourceHandler\ContentTypeFilterMiddleware;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
+use ZendTest\Expressive\Swoole\AssertResponseTrait;
+
+class ContentTypeFilterMiddlewareTest extends TestCase
+{
+    use AssertResponseTrait;
+
+    public function setUp()
+    {
+        $this->request = $this->prophesize(Request::class)->reveal();
+    }
+
+    public function testPassingNoArgumentsToConstructorSetsDefaultTypeMap()
+    {
+        $middleware = new ContentTypeFilterMiddleware();
+        $this->assertAttributeSame(
+            ContentTypeFilterMiddleware::TYPE_MAP_DEFAULT,
+            'typeMap',
+            $middleware
+        );
+    }
+
+    public function testCanProvideAlternateTypeMapViaConstructor()
+    {
+        $typeMap = [
+            'asc' => 'application/octet-stream',
+        ];
+        $middleware = new ContentTypeFilterMiddleware($typeMap);
+        $this->assertAttributeSame($typeMap, 'typeMap', $middleware);
+    }
+
+    public function testMiddlewareReturnsFailureResponseIfFileNotFound()
+    {
+        $next = function ($request, $filename) {
+            TestCase::fail('Should not have invoked next middleware');
+        };
+        $middleware = new ContentTypeFilterMiddleware();
+
+        $response = $middleware($this->request, __DIR__ . '/not-a-valid-file.png', $next);
+
+        $this->assertInstanceOf(StaticResourceResponse::class, $response);
+        $this->assertTrue($response->isFailure());
+    }
+
+    public function testMiddlewareReturnsFailureResponseIfFileNotAllowedByTypeMap()
+    {
+        $next = function ($request, $filename) {
+            TestCase::fail('Should not have invoked next middleware');
+        };
+        $middleware = new ContentTypeFilterMiddleware([
+            'txt' => 'text/plain',
+        ]);
+
+        $response = $middleware($this->request, __DIR__ . '/../image.png', $next);
+
+        $this->assertInstanceOf(StaticResourceResponse::class, $response);
+        $this->assertTrue($response->isFailure());
+    }
+
+    public function testMiddlewareAddsContentTypeToResponseWhenResourceLocatedAndAllowed()
+    {
+        $expected = new StaticResourceResponse();
+        $next = function ($request, $filename) use ($expected) {
+            return $expected;
+        };
+        $middleware = new ContentTypeFilterMiddleware();
+
+        $response = $middleware($this->request, __DIR__ . '/../TestAsset/image.png', $next);
+
+        $this->assertSame($expected, $response);
+        $this->assertHeaderSame('image/png', 'Content-Type', $response);
+    }
+}

--- a/test/StaticResourceHandler/GzipMiddlewareTest.php
+++ b/test/StaticResourceHandler/GzipMiddlewareTest.php
@@ -129,6 +129,7 @@ class GzipMiddlewareTest extends TestCase
         $swooleResponse = $this->prophesize(SwooleHttpResponse::class);
         $swooleResponse->header('Content-Encoding', $encoding, true)->shouldBeCalled();
         $swooleResponse->header('Connection', 'close', true)->shouldBeCalled();
+        $swooleResponse->header('content-length', mb_strlen($expected), true)->shouldBeCalled();
 
         $swooleResponse->write($expected)->shouldBeCalled();
         $swooleResponse->end()->shouldBeCalled();

--- a/test/StaticResourceHandler/GzipMiddlewareTest.php
+++ b/test/StaticResourceHandler/GzipMiddlewareTest.php
@@ -129,7 +129,7 @@ class GzipMiddlewareTest extends TestCase
         $swooleResponse = $this->prophesize(SwooleHttpResponse::class);
         $swooleResponse->header('Content-Encoding', $encoding, true)->shouldBeCalled();
         $swooleResponse->header('Connection', 'close', true)->shouldBeCalled();
-        $swooleResponse->header('content-length', mb_strlen($expected), true)->shouldBeCalled();
+        $swooleResponse->header('Content-Length', mb_strlen($expected), true)->shouldBeCalled();
 
         $swooleResponse->write($expected)->shouldBeCalled();
         $swooleResponse->end()->shouldBeCalled();

--- a/test/StaticResourceHandler/IntegrationTest.php
+++ b/test/StaticResourceHandler/IntegrationTest.php
@@ -46,7 +46,9 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'image/png', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', 'GET, HEAD, OPTIONS', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->status(405)->shouldBeCalled();
         $response->end()->shouldBeCalled();
         $response->sendfile()->shouldNotBeCalled();
@@ -71,7 +73,9 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'image/png', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', 'GET, HEAD, OPTIONS', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->status(200)->shouldBeCalled();
         $response->end()->shouldBeCalled();
         $response->sendfile()->shouldNotBeCalled();
@@ -103,6 +107,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldBeCalled();
         $response->header('Cache-Control', 'public, no-transform', true)->shouldBeCalled();
         $response->header('Last-Modified', $lastModifiedFormatted, true)->shouldBeCalled();
         $response->header('ETag', $etag, true)->shouldBeCalled();
@@ -144,6 +149,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Cache-Control', 'public, no-transform', true)->shouldBeCalled();
         $response->header('Last-Modified', $lastModifiedFormatted, true)->shouldBeCalled();
         $response->header('ETag', $etag, true)->shouldBeCalled();
@@ -188,6 +194,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', 'GET, HEAD, OPTIONS', true)->shouldBeCalled();
         $response->header('Cache-Control', 'public, no-transform', true)->shouldBeCalled();
         $response->header('Last-Modified', $lastModifiedFormatted, true)->shouldBeCalled();
@@ -236,6 +243,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', 'public, no-transform', true)->shouldBeCalled();
         $response->header('Last-Modified', Argument::any())->shouldNotBeCalled();
@@ -281,6 +289,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', 'public, no-transform', true)->shouldBeCalled();
         $response->header('Last-Modified', Argument::any())->shouldNotBeCalled();
@@ -325,6 +334,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', Argument::any())->shouldNotBeCalled();
         $response->header('Last-Modified', Argument::any())->shouldNotBeCalled();
@@ -370,6 +380,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', Argument::any())->shouldNotBeCalled();
         $response->header('Last-Modified', Argument::any())->shouldNotBeCalled();
@@ -411,6 +422,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', Argument::any())->shouldNotBeCalled();
         $response->header('Last-Modified', Argument::any())->shouldNotBeCalled();
@@ -455,6 +467,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldNotBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', Argument::any())->shouldNotBeCalled();
         $response->header('Last-Modified', $lastModifiedFormatted, true)->shouldBeCalled();
@@ -498,6 +511,7 @@ class IntegrationTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'text/plain', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldBeCalled();
         $response->header('Allow', Argument::any())->shouldNotBeCalled();
         $response->header('Cache-Control', Argument::any())->shouldNotBeCalled();
         $response->header('Last-Modified', $lastModifiedFormatted, true)->shouldBeCalled();

--- a/test/StaticResourceHandlerFactoryTest.php
+++ b/test/StaticResourceHandlerFactoryTest.php
@@ -86,20 +86,26 @@ class StaticResourceHandlerFactoryTest extends TestCase
             'docRoot',
             $handler
         );
-        $this->assertAttributeSame(
-            $config['zend-expressive-swoole']['swoole-http-server']['static-files']['type-map'],
-            'typeMap',
-            $handler
-        );
 
         $r = new ReflectionProperty($handler, 'middleware');
         $r->setAccessible(true);
         $middleware = $r->getValue($handler);
 
+        $this->assertHasMiddlewareOfType(StaticResourceHandler\ContentTypeFilterMiddleware::class, $middleware);
         $this->assertHasMiddlewareOfType(StaticResourceHandler\MethodNotAllowedMiddleware::class, $middleware);
         $this->assertHasMiddlewareOfType(StaticResourceHandler\OptionsMiddleware::class, $middleware);
         $this->assertHasMiddlewareOfType(StaticResourceHandler\HeadMiddleware::class, $middleware);
         $this->assertHasMiddlewareOfType(StaticResourceHandler\ClearStatCacheMiddleware::class, $middleware);
+
+        $contentTypeFilter = $this->getMiddlewareByType(
+            StaticResourceHandler\ContentTypeFilterMiddleware::class,
+            $middleware
+        );
+        $this->assertAttributeSame(
+            $config['zend-expressive-swoole']['swoole-http-server']['static-files']['type-map'],
+            'typeMap',
+            $contentTypeFilter
+        );
 
         $clearStatsCache = $this->getMiddlewareByType(
             StaticResourceHandler\ClearStatCacheMiddleware::class,

--- a/test/StaticResourceHandlerTest.php
+++ b/test/StaticResourceHandlerTest.php
@@ -87,6 +87,7 @@ class StaticResourceHandlerTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class);
         $response->header('Content-Type', 'image/png', true)->shouldBeCalled();
+        $response->header('content-length', Argument::any(), true)->shouldBeCalled();
         $response->status(200)->shouldBeCalled();
         $response->end()->shouldNotBeCalled();
         $response->sendfile($this->docRoot . '/image.png')->shouldBeCalled();

--- a/test/SwooleRequestHandlerRunnerTest.php
+++ b/test/SwooleRequestHandlerRunnerTest.php
@@ -23,6 +23,7 @@ use Zend\Expressive\Swoole\PidManager;
 use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
 use Zend\Expressive\Swoole\ServerFactory;
 use Zend\Expressive\Swoole\StaticResourceHandlerInterface;
+use Zend\Expressive\Swoole\StaticResourceHandler\StaticResourceResponse;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 
 class SwooleRequestHandlerRunnerTest extends TestCase
@@ -87,12 +88,8 @@ class SwooleRequestHandlerRunnerTest extends TestCase
             ->willReturn(null);
 
         $this->staticResourceHandler
-            ->isStaticResource(Argument::any())
-            ->willReturn(false);
-
-        $this->staticResourceHandler
-            ->sendStaticResource(Argument::any())
-            ->shouldNotBeCalled();
+            ->processStaticResource(Argument::any())
+            ->willReturn(null);
 
         $requestHandler = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
@@ -209,11 +206,8 @@ class SwooleRequestHandlerRunnerTest extends TestCase
             ->shouldBeCalled();
 
         $this->staticResourceHandler
-            ->isStaticResource($request)
-            ->willReturn(false);
-        $this->staticResourceHandler
-            ->sendStaticResource(Argument::any())
-            ->shouldNotBeCalled();
+            ->processStaticResource($request, $response->reveal())
+            ->willReturn(null);
 
         $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),
@@ -245,12 +239,10 @@ class SwooleRequestHandlerRunnerTest extends TestCase
 
         $response = $this->prophesize(SwooleHttpResponse::class)->reveal();
 
+        $staticResponse = $this->prophesize(StaticResourceResponse::class)->reveal();
         $this->staticResourceHandler
-            ->isStaticResource($request)
-            ->willReturn(true);
-        $this->staticResourceHandler
-            ->sendStaticResource($request, $response)
-            ->shouldBeCalled();
+            ->processStaticResource($request, $response)
+            ->willReturn($staticResponse);
 
         $runner = new SwooleRequestHandlerRunner(
             $this->requestHandler->reveal(),


### PR DESCRIPTION
This patch provides improved logging support for the `SwooleRequestHandlerRunner`.

First, it changes logging internally to use appropriate PSR-3 log priorities. Server start, stop, reload, etc. events now use `notice()`.

Second, it provides flexible and robust access logging for the server. It does this by porting many of the capabilities of [middlewares/access-log](https://github.com/middlewares/access-log) to this package, but modifying the support to work with Swoole requests and the new `SwooleStaticResponse` class (which has been updated to provide data access for the purpose of logging). These capabilities allow us to use standard formats used by many web servers, as introduced by [Apache](http://httpd.apache.org/docs/current/mod/mod_log_config.html).

The patch creates a new `Log` subnamespace with the following interfaces and classes:

- `Log\AccessLogInterface` extends PSR-3, and adds the methods `logAccessForPsr7Resource` and `logAccessForStaticResource`. Each takes a Swoole request and the associated response type.

- `AccessLogDataMap` is used to pull logging data from the relevant request and response resources. It creates a request-end timestamp during instantiation, and accepts a flag indicating whether or not to perform hostname lookups (disabled by default).

- `AccessLogFormatterInterface` defines a single method, `format()`, which accepts an `AccessLogDataMap` and returns a string.

- `AccessLogFormatter` receives a logging format to its constructor, and use that format when its `format()` method is called to generate the message string for the logger, using the provided `AccessLogDataMap`.

- `Psr3AccessLogDecorator` implements `AccessLogInterface` and accepts a PSR-3 logger, `AccessLogFormatterInterface` instance, and a boolean indicating whether or not to perform hostname lookups. The PSR-3 methods all proxy to the decorated logger. The `AccessLogInterface`- specific methods each generate an `AccessLogDataMap`, and then pass the value to the composed `AccessLogFormatter` to generate a message.  If the response status code is >=400, it uses the logger's `error()` method, otherwise its `info()` method.

- `AccessLogFactory` grabs the PSR-3 `LoggerInterface` service if it exists, the `AccessLogFormatterInterface` service if it exists, and any configuration under `zend-expressive-swoole.swoole-http-server.logger` to create a `Psr3AccessLogDecorator`. Configuration options include: 
  - `format`: defaults to `AccessLogFormatter::FORMAT_COMMON`
  - `use-hostname-lookup`: defaults to `false`

  If no PSR-3 logger is available, it uses the shipped `StdoutLogger` implementation. If no `AccessLogFormatterInterface` service exists, it creates and uses an `AccessLogFormatter` instance.

Additionally, the `StdoutLogger` has been moved to this subnamespace.

Finally, `SwooleRequestHandlerRunner` now composes an `AccessLogInterface` instance instead of a PSR-3 logger instance. Log events around server start/stop/reload/etc. now use the `notice` priority. Request logs happen after the response has been sent, using the appropriate `AccessLogInterface` methods. This approach means that logging will not impact clients.

To make these changes possible, I had to refactor the static resource middleware to allow access to the response status and content length by the logger. These changes include:

- The `StaticResourceHandlerInterface` now only defines the method `processStaticResource(Swoole\Http\Request $request, Swoole\Http\Response $response) : ?StaticResourceHandler\StaticResourceResponse`

- It adds the following methods to `StaticResourceResponse`:
  - `markAsFailure()`
  - `isFailure()`
  - `setContentLength()`
  - `getContentLength()`
  - `getStatus()`
  - `getHeader(string $name) : string`
  - `getHeaderSize() : int`

- It extracts the type map and cache to a new middleware, `ContentTypeFilterMiddleware`.  This middleware returns a failure response if it cannot match the file or the file does not exist. Otherwise, it delegates to the next middleware, and adds an appropriate `Content-Type` header to the response before returning it.

- `StaticResourceHandler` now only composes the document root and middleware. `processStaticResource()` no longer does type mapping, but instead introspects the response returned from middleware to see if it is a failure; it then returns null. Otherwise, it sends the swoole response and returns the static response.

- The default response sender and the `GzipMiddleware` response sender now calculate the content length and use it to both send a `Content-Length` header as well as provide it to the static response.

These changes simplify `StaticResourceHandler` further, and make testing even easier (other than integration testing, which is largely unchanged).

## TODO

- [x] Ensure documentation of existing classes is up-to-date.
- [x] Write new chapter on logging.
- [x] Update CHANGELOG.