### PR TITLE
Added support of Swoole 4.1 coroutine

### DIFF
--- a/docs/book/how_it_works.md
+++ b/docs/book/how_it_works.md
@@ -78,3 +78,11 @@ This impressive result is primarily due to the shared memory approach of Swoole.
 Unlike traditional apache/php-fpm usage, the memory allocated in Swoole will not
 be freed after a request. This allows application configuration and artifacts
 (such as middleware and handlers) to persist between requests and processes.
+
+Under Swoole 4.1+, for even better performance, you can enable the option
+`zend-expressive-swoole.swoole-http-server.options.enable_coroutine`. When this
+is enabled, Swoole will run most I/O processes in coroutines. Doing so provides
+approximately **10 times faster performance** than without coroutines, meaning a
+Swoole-based application can be 40 to 50 times faster than running under nginx
+or Apache. Performance improves with the number of workers (which are restricted
+by the amount of memory); as such, performance can increase from these numbers.

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -85,11 +85,16 @@ return [
         'swoole-http-server' => [
             'host' => '192.168.0.1',
             'port' => 9501,
-            'mode' => SWOOLE_BASE,
-            'protocol' => SWOOLE_SOCK_TCP | SWOOLE_SSL,
+            'mode' => SWOOLE_BASE, // SWOOLE_BASE or SWOOLE_PROCESS;
+                                   // SWOOLE_BASE is the default
+            'protocol' => SWOOLE_SOCK_TCP | SWOOLE_SSL, // SSL-enable the server
             'options' => [
+                // Set the SSL certificate and key paths for SSL support:
                 'ssl_cert_file' => 'path/to/ssl.crt',
                 'ssl_key_file' => 'path/to/ssl.key',
+                // Available in Swoole 4.1 and up; enables coroutine support
+                // for most I/O operations:
+                'enable_coroutine' => true,
             ],
         ],
     ],

--- a/src/ServerFactory.php
+++ b/src/ServerFactory.php
@@ -114,7 +114,7 @@ class ServerFactory
         $this->protocol = $protocol;
         $this->options = $options;
         // Bound with the 'enable_coroutine' option, and this option ONLY available for swoole 4.0.0 or later.
-        $this->enableCoroutine = $options['enable_coroutine'];
+        $this->enableCoroutine = $options['enable_coroutine'] ?? false;
     }
 
     /**


### PR DESCRIPTION
Swoole 4.1 is ready, there's a incredible feature that could let PDO, Mysqli, redis, soap, stream_socket_client, fsockopen,file_get_contents (Most of I/O driver) become a non-blocking async client needs just one line code `Swoole\Runtime::enableCorotuine()`.

> Notice that the documents in swoole official site about coroutine are outdated, I have been contacted with swoole developer team.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
The server still running in I/O blocking driver before, even using swoole, when the  request handler processing in I/O request, like DB, Cache request, it will block the hold process, if the server running in 4 workers, and per request consumes 1 sec, the QPS is 4/sec, But, when running in coroutine, all I/O will switch to Non-Blocking driver, the QPS will be unlimited (Actually limited by memory of server, and limited by MySQL Server or Redis Server etc.).
  - [x] How will users use the new feature?
```
[
    'zend-expressive-swoole' => [
        'swoole-http-server' => [
            'options' => [
                'enable_coroutine' => true,
            ],
        ],
    ]
]
```
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests

I make some tests, the results are below, server running in coroutine mode about **1350 times** fater than non-coroutine mode in this test case.
> The tests result maybe wrong, because my MySQL server cannot handle the huge connection numbers like this, I have to develop a Connection Pool before this, anyone could provide another tests result would be better, but coroutine still faster than non-coroutine is a fact.
I write the code in a Controller as below.
```
$pdo = new \PDO($dsn, $user, $password);
$pdo->query('select sleep(1)');
```
And then run the server in `non-coroutine` mode and `coroutine` mode.
Stress testing command: `ab -k -c 1000 -t 10 http://127.0.0.1:9501/`

Non-Coroutine mode:
![_ _20180831204013](https://user-images.githubusercontent.com/12077148/44915223-0317e580-ad65-11e8-8797-4ba44c40ac94.png)


Coroutine mode:
![_ _20180831203911](https://user-images.githubusercontent.com/12077148/44915236-0a3ef380-ad65-11e8-8351-96889115be7b.png)
