### PR TITLE
Update how request handler logs errors due to inability to marshal a request

### DIFF
--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -329,6 +329,5 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
     ) : void {
         $response = ($this->serverRequestErrorResponseGenerator)($exception);
         $emitter->emit($response);
-        $this->logger->logAccessForPsr7Resource($request, $psr7Response);
     }
 }

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -325,9 +325,11 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
      */
     private function emitMarshalServerRequestException(
         EmitterInterface $emitter,
-        Throwable $exception
+        Throwable $exception,
+        SwooleHttpRequest $request
     ) : void {
-        $response = ($this->serverRequestErrorResponseGenerator)($exception);
-        $emitter->emit($response);
+        $psr7Response = ($this->serverRequestErrorResponseGenerator)($exception);
+        $emitter->emit($psr7Response);
+        $this->logger->logAccessForPsr7Resource($request, $psr7Response);
     }
 }


### PR DESCRIPTION
Remove useless(or error) code, there are no `$request` and `$psr7Response` variables in `emitMarshalServerRequestException` method.