### PR TITLE
Hotfix swoole raw content on empty body

### DIFF
--- a/src/SwooleStream.php
+++ b/src/SwooleStream.php
@@ -252,6 +252,6 @@ final class SwooleStream implements StreamInterface
         if ($this->body) {
             return;
         }
-        $this->body = $this->request->rawContent();
+        $this->body = $this->request->rawContent() ?: '';
     }
 }

--- a/test/SwooleStreamTest.php
+++ b/test/SwooleStreamTest.php
@@ -32,6 +32,18 @@ class SwooleStreamTest extends TestCase
         $this->stream = new SwooleStream($this->request->reveal());
     }
 
+    public function testGetContentsWithNoRawContent()
+    {
+        $request = $this->prophesize(SwooleHttpRequest::class);
+        $request
+            ->rawcontent()
+            ->willReturn(false);
+
+        $stream = new SwooleStream($request->reveal());
+
+        $this->assertEquals('', $stream->getContents());
+    }
+
     public function testStreamIsAPsr7StreamInterface()
     {
         $this->assertInstanceOf(StreamInterface::class, $this->stream);


### PR DESCRIPTION
Trying to getting stream contents on empty body (i.e. GET requests) results in an error because `Swoole\Http\Request::rawcontent()` returns `false` and then the SwooleStream attempts to get body length with `strlen()` on `false`.

This PR fixes this issue.