### PR TITLE
Move CLI tooling to dedicated binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- [#43](https://github.com/zendframework/zend-expressive-swoole/pull/43) adds the class `Zend\Expressive\Swoole\WhoopsPrettyPageHandlerDelegator`, and registers
-  it to the service `Zend\Expressive\WhoopsPageHandler`. The delegator calls `handleUnconditionally()` on the
-  handler in order to ensure it will operate under the CLI SAPI that Swoole runs under.
+- [#46](https://github.com/zendframework/zend-expressive-swoole/pull/46) adds a new command for the command line tooling, `status`; the command
+  simply tells you if the server is running or not.
+
+- [#43](https://github.com/zendframework/zend-expressive-swoole/pull/43) adds the class `Zend\Expressive\Swoole\WhoopsPrettyPageHandlerDelegator`,
+  and registers it to the service `Zend\Expressive\WhoopsPageHandler`. The
+  delegator calls `handleUnconditionally()` on the handler in order to ensure it
+  will operate under the CLI SAPI that Swoole runs under.
 
 - [#40](https://github.com/zendframework/zend-expressive-swoole/pull/40) adds the class `Zend\Expressive\Swoole\HttpServerFactory`, which
   generates a `Swoole\Http\Server` instance based on provided configuration; it
@@ -19,6 +23,14 @@ All notable changes to this project will be documented in this file, in reverse 
   [enabling async task workers](https://docs.zendframework.com/zend-expressive-swoole/v2/async-tasks/).
 
 ### Changed
+
+- [#46](https://github.com/zendframework/zend-expressive-swoole/pull/46) moves the command line utilities for controlling the web server out of
+  the application runner, and into a new vendor binary, `zend-expressive-swoole`
+  (called via `./vendor/bin/zend-expressive-swoole`). This change was required
+  to allow us to expose the `Swoole\Http\Server` instance as a service, and has
+  the added benefit that `reload` operations now will fully stop and start the
+  server, allowing it to pick up configuration and code changes. **You will need
+  to update any deployment scripts to use the new vendor binary.**
 
 - [#40](https://github.com/zendframework/zend-expressive-swoole/pull/40) changes how you configure Swoole's coroutine support. Previously, you
   would toggle the configuration flag `zend-expressive-swoole.swoole-http-server.options.enable_coroutine`;

--- a/README.md
+++ b/README.md
@@ -67,7 +67,14 @@ Once you have performed the configuration steps as outlined above, you can run
 an Expressive application with Swoole using the following command:
 
 ```bash
-php public/index.php start
+$ ./vendor/bin/zend-expressive-swoole start
+```
+
+Call the command without arguments to get a list of available commands, and use
+the `help` meta-argument to get help on individual commands:
+
+```bash
+$ ./vendor/bin/zend-expressive-swoole help start
 ```
 
 ## Documentation

--- a/bin/zend-expressive-swoole
+++ b/bin/zend-expressive-swoole
@@ -47,6 +47,7 @@ chdir($cwd);
 
 require 'vendor/autoload.php';
 
+// Setup/verify application DI container
 $containerFile = sprintf('%s/config/container.php', $cwd);
 if (! file_exists($containerFile)) {
     fwrite(STDERR, sprintf(
@@ -60,6 +61,7 @@ if (! file_exists($containerFile)) {
 $container = require $containerFile;
 $version   = strstr(Versions::getVersion('zendframework/zend-expressive-swoole'), '@', true);
 
+// Create, populate, and run the CLI tooling
 $commandLine = new CommandLine('Expressive web server', $version);
 $commandLine->setAutoExit(true);
 $commandLine->setCommandLoader(new ContainerCommandLoader($container, [

--- a/bin/zend-expressive-swoole
+++ b/bin/zend-expressive-swoole
@@ -1,0 +1,71 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Start, stop, and reload the HTTP server.
+ *
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use PackageVersions\Versions;
+use Symfony\Component\Console\Application as CommandLine;
+use Symfony\Component\Console\CommandLoader\ContainerCommandLoader;
+
+use function chdir;
+use function file_exists;
+use function fwrite;
+use function is_dir;
+use function sprintf;
+use function strstr;
+use function str_repeat;
+
+use const PHP_EOL;
+use const STDERR;
+
+// Setup/verify autoloading
+$depth = 1;
+while ($depth <= 4) {
+    $dir = sprintf('%s/%s', __DIR__, str_repeat('../', $depth));
+    if (is_dir($dir . 'vendor')) {
+        $cwd = $dir;
+    }
+
+    $depth += 1;
+}
+
+if (! isset($cwd)) {
+    fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
+    exit(1);
+}
+
+chdir($cwd);
+
+require 'vendor/autoload.php';
+
+$containerFile = sprintf('%s/config/container.php', $cwd);
+if (! file_exists($containerFile)) {
+    fwrite(STDERR, sprintf(
+        'No container file (%s) detected; are you in an Expressive application?%s',
+        $containerFile,
+        PHP_EOL
+    ));
+    exit(1);
+}
+
+$container = require $containerFile;
+$version   = strstr(Versions::getVersion('zendframework/zend-expressive-swoole'), '@', true);
+
+$commandLine = new CommandLine('Expressive web server', $version);
+$commandLine->setAutoExit(true);
+$commandLine->setCommandLoader(new ContainerCommandLoader($container, [
+    'reload' => ReloadCommand::class,
+    'start'  => StartCommand::class,
+    'status' => StatusCommand::class,
+    'stop'   => StopCommand::class,
+]));
+$commandLine->run();

--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,9 @@
             "ZendTest\\Expressive\\Swoole\\": "test/"
         }
     },
+    "bin": [
+        "bin/zend-expressive-swoole"
+    ],
     "config": {
         "sort-packages": true
     },

--- a/docs/book/v2/command-line.md
+++ b/docs/book/v2/command-line.md
@@ -1,0 +1,171 @@
+# Command Line Tooling
+
+This package ships the vendor binary `zend-expressive-swoole`. It provides the
+following commands:
+
+- `start` to start the server
+- `stop` to stop the server (when run in daemonized mode)
+- `reload` to reload the server (when run in daemonized mode)
+- `status` to determine the server status (running or not running)
+
+You may obtain help for each command using the `help` meta-command:
+
+```bash
+$ ./vendor/bin/zend-expressive-swoole help start
+```
+
+The `stop`, `status`, and `reload` commands are sufficiently generic to work
+regardless of runtime or application, as they work directly with the Swoole
+process manager. The `start` command, however, may need customizations if you
+have customized your application bootstrap.
+
+## The start command
+
+The `start` command will start the web server using the following steps:
+
+- It pulls the `Swoole\Http\Server` service from the application dependency
+  injection container, and calls `set()` on it with options denoting the number
+  of workers to run (provided via the `--num-workers` or `-w` option), and
+  whether or not to daemonize the server (provided via the `--daemonize` or `-d`
+  option).
+
+- It pulls the `Zend\Expressive\Application` and
+  `Zend\Expressive\MiddlewareFactory` services from the container.
+
+- It loads the `config/pipeline.php` and `config/routes.php` files, invoking
+  their return values with the application, middleware factory, and dependency
+  injection container instances.
+
+- It calls the `run()` method of the application instance.
+
+These are roughly the steps taken within the application bootstrap
+(`public/index.php`) of the Expressive skeleton application.
+
+### Writing a custom start command
+
+If your application needs alternate bootstrapping (e.g., if you have modified
+the `public/index.php`, or if you are using this package with a different
+middleware runtime), we recommend writing a custom `start` command.
+
+As an example, let's say you have altered your application such that you're
+defining your routes in multiple files, and instead of:
+
+```php
+(require 'config/routes.php')($app, $factory, $container);
+```
+
+you instead have something like:
+
+```php
+$handle = opendir('config/routes/');
+while (false !== ($entry = readdir($handle))) {
+    if (false === strrpos($entry, '.php')) {
+        continue;
+    }
+    (require $entry)($app, $factory, $container);
+}
+```
+
+You could write a command such as the following:
+
+```php
+// In src/App/Command/StartCommand.php:
+
+namespace App\Command;
+
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as SwooleHttpServer;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Swoole\Command\StartCommand as BaseStartCommand;
+use Zend\Expressive\Swoole\PidManager;
+
+class StartCommand extends BaseStartCommand
+{
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        // This functionality is identical to the base start command, and should
+        // be copy and pasted to your implementation:
+        $this->pidManager = $this->container->get(PidManager::class);
+        if ($this->isRunning()) {
+            $output->writeln('<error>Server is already running!</error>');
+            return 1;
+        }
+
+        $server = $this->container->get(SwooleHttpServer::class);
+        $server->set([
+            'daemonize' => $input->getOption('daemonize'),
+            'worker_num' => $input->getOption('num-workers') ?? self::DEFAULT_NUM_WORKERS,
+        ]);
+
+        /** @var \Zend\Expressive\Application $app */
+        $app = $this->container->get(Application::class);
+
+        /** @var \Zend\Expressive\MiddlewareFactory $factory */
+        $factory = $this->container->get(MiddlewareFactory::class);
+
+        // Execute programmatic/declarative middleware pipeline and routing
+        // configuration statements
+        (require 'config/pipeline.php')($app, $factory, $this->container);
+
+        //
+        // This is the new code from above:
+        //
+        $handle = opendir(getcwd() . '/config/routes/');
+        while (false !== ($entry = readdir($handle))) {
+            if (false === strrpos($entry, '.php')) {
+                continue;
+            }
+            (require $entry)($app, $factory, $container);
+        }
+
+        // And now we return to the original code:
+
+        // Run the application
+        $app->run();
+
+        return 0;
+    }
+}
+```
+
+You will also need to write a factory for the class:
+
+```php
+// In src/App/Command/StartCommandFactory.php:
+
+namespace App\Command;
+
+use Psr\Container\ContainerInterface;
+
+class StartCommandFactory
+{
+    public function __invoke(ContainerInterface $container) : StartCommand
+    {
+        return new StartCommand($container);
+    }
+}
+```
+
+If this is all you're changing, you can map this new command to the existing
+`Zend\Expressive\Swoole\Command\StartCommand` service within your configuration:
+
+```php
+// in config/autoload/dependencies.global.php:
+
+use App\Command\StartCommandFactory;
+use Zend\Expressive\Swoole\Command\StartCommand;
+
+return [
+    'dependencies' => [
+        'factories' => [
+            StartCommand::class => StartCommandFactory::class,
+        ],
+    ],
+];
+```
+
+Since the `zend-expressive-swoole` binary uses your application configuration
+and container, this will substitute your command for the shipped command!

--- a/docs/book/v2/how-it-works.md
+++ b/docs/book/v2/how-it-works.md
@@ -14,7 +14,7 @@ enables the execution of an Expressive application inside the `on('request')`
 event of `Swoole\Http\Server`. This runner is implemented in the
 `Zend\Expressive\Swoole\SwooleRequestHandlerRunner` class.
 
-The basic implementation looks similar to the following:
+The basic implementation acts similar to the following:
 
 ```php
 public function run() : void

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -34,10 +34,21 @@ application from the command line, **without requiring a web server**.
 You can run the application using the following command:
 
 ```bash
-$ php public/index.php
+$ ./vendor/bin/zend-expressive-swoole start
 ```
 
 This command will execute Swoole on `localhost` via port `8080`.
+
+> ### Other commands
+>
+> To get a list of all available commands, run the command without arguments:
+>
+> ```bash
+> $ ./vendor/bin/zend-expressive-swoole
+> ```
+>
+> If you add the argument `help` before any command name, the tooling will
+> provide you with more detailed information on that command.
 
 > ### Expressive skeleton versions prior to 3.1.0
 >

--- a/docs/book/v2/migration.md
+++ b/docs/book/v2/migration.md
@@ -3,6 +3,31 @@
 This document covers changes between version 1 and version 2, and how you may
 update your code to adapt to them.
 
+## Controlling the server
+
+In version 1, you would execute the web server via the entry script, e.g.:
+
+```bash
+$ php public/index.php start
+```
+
+With version 2, we ship the command line tools for controlling your server via
+the binary `zend-expressive-swoole`:
+
+```bash
+# Start the server:
+$ ./vendor/bin/zend-expressive-swoole start -d
+# Reload the server:
+$ ./vendor/bin/zend-expressive-swoole reload
+# Stop the server:
+$ ./vendor/bin/zend-expressive-swoole stop
+```
+
+While you can still call `php public/index.php`, you cannot daemonize the server
+using that command, nor reload or stop it (other than using `Ctrl-C`). You will
+need to change any deployment commands you currently use to consume the new
+command line tooling.
+
 ## Coroutine support
 
 In version 1, to enable Swoole's coroutine support, you were expected to pass a

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 docs_dir: docs/book
 site_dir: docs/html
 pages:
-    - index.md
+    - Home: index.md
     - Introduction: v2/intro.md
     - Reference:
       - "Static Resources": v2/static-resources.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,11 +2,12 @@ docs_dir: docs/book
 site_dir: docs/html
 pages:
     - index.md
-    - Intro: v2/intro.md
+    - Introduction: v2/intro.md
     - Reference:
       - "Static Resources": v2/static-resources.md
       - Logging: v2/logging.md
       - "Async Tasks": v2/async-tasks.md
+      - "Command Line Tooling": v2/command-line.md
       - "How it works": v2/how-it-works.md
       - "Considerations when using Swoole": v2/considerations.md
       - Migration: v2/migration.md

--- a/src/Command/IsRunningTrait.php
+++ b/src/Command/IsRunningTrait.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Swoole\Process as SwooleProcess;
+use Zend\Expressive\Swoole\PidManager;
+
+trait IsRunningTrait
+{
+    /**
+     * Is the swoole HTTP server running?
+     */
+    public function isRunning() : bool
+    {
+        $pids = $this->pidManager->read();
+
+        if ([] === $pids) {
+            return false;
+        }
+
+        [$masterPid, $managerPid] = $pids;
+
+        if ($managerPid) {
+            // Swoole process mode
+            return $masterPid && $managerPid && SwooleProcess::kill((int) $managerPid, 0);
+        }
+
+        // Swoole base mode, no manager process
+        return $masterPid && SwooleProcess::kill((int) $masterPid, 0);
+    }
+}

--- a/src/Command/ReloadCommand.php
+++ b/src/Command/ReloadCommand.php
@@ -10,9 +10,14 @@ declare(strict_types=1);
 namespace Zend\Expressive\Swoole\Command;
 
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
+
+use function sleep;
+
+use const SWOOLE_PROCESS;
 
 class ReloadCommand extends Command
 {
@@ -26,13 +31,13 @@ configuration value is set to SWOOLE_PROCESS.
 EOH;
 
     /**
-     * @var SwooleRequestHandlerRunner
+     * @var int
      */
-    private $runner;
+    private $serverMode;
 
-    public function __construct(SwooleRequestHandlerRunner $runner, string $name = null)
+    public function __construct(int $serverMode, string $name = 'reload')
     {
-        $this->runner = $runner;
+        $this->serverMode = $serverMode;
         parent::__construct($name);
     }
 
@@ -40,16 +45,58 @@ EOH;
     {
         $this->setDescription('Reload the web server.');
         $this->setHelp(self::HELP);
+        $this->addOption(
+            'num-workers',
+            'w',
+            InputOption::VALUE_REQUIRED,
+            'Number of worker processes to use after reloading.'
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        if ($this->runner->reloadWorker()) {
-            $output->writeln('<info>Server reloaded</info>');
-            return 0;
+        if ($this->serverMode !== SWOOLE_PROCESS) {
+            $output->writeln(
+                '<error>Server is not configured to run in SWOOLE_PROCESS mode;'
+                . ' cannot reload</error>'
+            );
+            return 1;
         }
 
-        $output->writeln('<error>Error reloading server; check logs for details</error>');
-        return 1;
+        $output->writeln('<info>Reloading server ...</info>');
+
+        $application = $this->getApplication();
+
+        $stop   = $application->find('stop');
+        $result = $stop->run(new ArrayInput([
+            'command' => 'stop',
+        ]), $output);
+
+        if (0 !== $result) {
+            $output->writeln('<error>Cannot reload server: unable to stop current server</error>');
+            return $result;
+        }
+
+        $output->write('<info>Waiting for 5 seconds to ensure server is stopped...</info>');
+        for ($i = 0; $i < 5; $i += 1) {
+            $output->write('<info>.</info>');
+            sleep(1);
+        }
+        $output->writeln('<info>[DONE]</info>');
+        $output->writeln('<info>Starting server</info>');
+
+        $start  = $application->find('start');
+        $result = $start->run(new ArrayInput([
+            'command'       => 'start',
+            '--daemonize'   => true,
+            '--num-workers' => $input->getOption('num-workers') ?? StartCommand::DEFAULT_NUM_WORKERS,
+        ]), $output);
+
+        if (0 !== $result) {
+            $output->writeln('<error>Cannot reload server: unable to start server</error>');
+            return $result;
+        }
+
+        return 0;
     }
 }

--- a/src/Command/ReloadCommandFactory.php
+++ b/src/Command/ReloadCommandFactory.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Psr\Container\ContainerInterface;
+
+use const SWOOLE_BASE;
+
+class ReloadCommandFactory
+{
+    public function __invoke(ContainerInterface $container) : ReloadCommand
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $mode   = $config['zend-expressive-swoole']['swoole-http-server']['mode'] ?? SWOOLE_BASE;
+
+        return new ReloadCommand($mode);
+    }
+}

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -9,14 +9,22 @@ declare(strict_types=1);
 
 namespace Zend\Expressive\Swoole\Command;
 
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as SwooleHttpServer;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Swoole\PidManager;
 
 class StartCommand extends Command
 {
+    use IsRunningTrait;
+
+    public const DEFAULT_NUM_WORKERS = 4;
+
     public const HELP = <<< 'EOH'
 Start the web server. If --daemonize is provided, starts the server as a
 background process and returns handling to the shell; otherwise, the
@@ -27,13 +35,13 @@ do not provide the option, 4 workers will be started.
 EOH;
 
     /**
-     * @var SwooleRequestHandlerRunner
+     * @var ContainerInterface
      */
-    private $runner;
+    private $container;
 
-    public function __construct(SwooleRequestHandlerRunner $runner, string $name = null)
+    public function __construct(ContainerInterface $container, string $name = 'start')
     {
-        $this->runner = $runner;
+        $this->container = $container;
         parent::__construct($name);
     }
 
@@ -57,10 +65,31 @@ EOH;
 
     protected function execute(InputInterface $input, OutputInterface $output) : int
     {
-        $this->runner->startServer([
+        $this->pidManager = $this->container->get(PidManager::class);
+        if ($this->isRunning()) {
+            $output->writeln('<error>Server is already running!</error>');
+            return 1;
+        }
+
+        $server = $this->container->get(SwooleHttpServer::class);
+        $server->set([
             'daemonize' => $input->getOption('daemonize'),
-            'worker_num' => $input->getOption('num-workers') ?? 4,
+            'worker_num' => $input->getOption('num-workers') ?? self::DEFAULT_NUM_WORKERS,
         ]);
+
+        /** @var \Zend\Expressive\Application $app */
+        $app = $this->container->get(Application::class);
+
+        /** @var \Zend\Expressive\MiddlewareFactory $factory */
+        $factory = $this->container->get(MiddlewareFactory::class);
+
+        // Execute programmatic/declarative middleware pipeline and routing
+        // configuration statements
+        (require 'config/pipeline.php')($app, $factory, $this->container);
+        (require 'config/routes.php')($app, $factory, $this->container);
+
+        // Run the application
+        $app->run();
 
         return 0;
     }

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -71,11 +71,20 @@ EOH;
             return 1;
         }
 
-        $server = $this->container->get(SwooleHttpServer::class);
-        $server->set([
-            'daemonize' => $input->getOption('daemonize'),
-            'worker_num' => $input->getOption('num-workers') ?? self::DEFAULT_NUM_WORKERS,
-        ]);
+        $serverOptions = [];
+        $daemonize     = $input->getOption('daemonize');
+        $numWorkers    = $input->getOption('num-workers');
+        if ($daemonize) {
+            $serverOptions['daemonize'] = $daemonize;
+        }
+        if (null !== $numWorkers) {
+            $serverOptions['worker_num'] = $numWorkers;
+        }
+
+        if ([] !== $serverOptions) {
+            $server = $this->container->get(SwooleHttpServer::class);
+            $server->set($serverOptions);
+        }
 
         /** @var \Zend\Expressive\Application $app */
         $app = $this->container->get(Application::class);

--- a/src/Command/StartCommandFactory.php
+++ b/src/Command/StartCommandFactory.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Psr\Container\ContainerInterface;
+
+class StartCommandFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new StartCommand($container);
+    }
+}

--- a/src/Command/StatusCommand.php
+++ b/src/Command/StatusCommand.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Swoole\Process as SwooleProcess;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Swoole\PidManager;
+
+class StatusCommand extends Command
+{
+    use IsRunningTrait;
+
+    public const HELP = <<< 'EOH'
+Find out if the server is running.
+
+This command is only relevant when the server was started using the
+--daemonize option.
+EOH;
+
+    /**
+     * @var PidManager
+     */
+    private $pidManager;
+
+    public function __construct(PidManager $pidManager, string $name = 'status')
+    {
+        $this->pidManager = $pidManager;
+        parent::__construct($name);
+    }
+
+    protected function configure() : void
+    {
+        $this->setDescription('Get the status of the web server.');
+        $this->setHelp(self::HELP);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output) : int
+    {
+        $message = $this->isRunning()
+            ? '<info>Server is running</info>'
+            : '<info>Server is not running</info>';
+
+        $output->writeln($message);
+
+        return 0;
+    }
+}

--- a/src/Command/StatusCommandFactory.php
+++ b/src/Command/StatusCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\PidManager;
+
+class StatusCommandFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new StatusCommand($container->get(PidManager::class));
+    }
+}

--- a/src/Command/StopCommandFactory.php
+++ b/src/Command/StopCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Command;
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\PidManager;
+
+class StopCommandFactory
+{
+    public function __invoke(ContainerInterface $container)
+    {
+        return new StopCommand($container->get(PidManager::class));
+    }
+}

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -48,6 +48,10 @@ class ConfigProvider
     {
         return [
             'factories'  => [
+                Command\ReloadCommand::class          => Command\ReloadCommandFactory::class,
+                Command\StartCommand::class           => Command\StartCommandFactory::class,
+                Command\StatusCommand::class          => Command\StatusCommandFactory::class,
+                Command\StopCommand::class            => Command\StopCommandFactory::class,
                 Log\AccessLogInterface::class         => Log\AccessLogFactory::class,
                 PidManager::class                     => PidManagerFactory::class,
                 SwooleRequestHandlerRunner::class     => SwooleRequestHandlerRunnerFactory::class,

--- a/test/Command/ReflectMethodTrait.php
+++ b/test/Command/ReflectMethodTrait.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use ReflectionMethod;
+use Symfony\Component\Console\Command\Command;
+
+trait ReflectMethodTrait
+{
+    public function reflectMethod(Command $command, string $method) : ReflectionMethod
+    {
+        $r = new ReflectionMethod($command, $method);
+        $r->setAccessible(true);
+        return $r;
+    }
+}

--- a/test/Command/ReloadCommandFactoryTest.php
+++ b/test/Command/ReloadCommandFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\Command\ReloadCommand;
+use Zend\Expressive\Swoole\Command\ReloadCommandFactory;
+
+use const SWOOLE_BASE;
+use const SWOOLE_PROCESS;
+
+class ReloadCommandFactoryTest extends TestCase
+{
+    public function testFactoryUsesDefaultsToCreateCommandWhenNoConfigPresent()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(false);
+        $container->get('config')->shouldNotBeCalled();
+
+        $factory = new ReloadCommandFactory();
+
+        $command = $factory($container->reveal());
+
+        $this->assertInstanceOf(ReloadCommand::class, $command);
+    }
+
+    public function configProvider() : iterable
+    {
+        yield 'empty' => [
+            [],
+            SWOOLE_BASE
+        ];
+
+        yield 'populated' => [
+            ['zend-expressive-swoole' => [
+                'swoole-http-server' => [
+                    'mode' => SWOOLE_PROCESS,
+                ],
+            ]],
+            SWOOLE_PROCESS
+        ];
+    }
+
+    /**
+     * @dataProvider configProvider
+     */
+    public function testFactoryUsesConfigToCreateCommandWhenPresent(array $config, int $mode)
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('config')->willReturn(true);
+        $container->get('config')->willReturn($config);
+
+        $factory = new ReloadCommandFactory();
+
+        $command = $factory($container->reveal());
+
+        $this->assertInstanceOf(ReloadCommand::class, $command);
+        $this->assertAttributeSame($mode, 'serverMode', $command);
+    }
+}

--- a/test/Command/ReloadCommandTest.php
+++ b/test/Command/ReloadCommandTest.php
@@ -1,0 +1,282 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Swoole\Command\ReloadCommand;
+
+use const SWOOLE_BASE;
+use const SWOOLE_PROCESS;
+
+class ReloadCommandTest extends TestCase
+{
+    use ReflectMethodTrait;
+
+    public function setUp()
+    {
+        $this->input  = $this->prophesize(InputInterface::class);
+        $this->output = $this->prophesize(OutputInterface::class);
+    }
+
+    public function mockApplication()
+    {
+        $helperSet   = $this->prophesize(HelperSet::class);
+        $application = $this->prophesize(Application::class);
+        $application
+            ->getHelperSet()
+            ->will([$helperSet, 'reveal']);
+        return $application;
+    }
+
+    public function testConstructorAcceptsServerMode()
+    {
+        $command = new ReloadCommand(SWOOLE_PROCESS);
+        $this->assertAttributeSame(SWOOLE_PROCESS, 'serverMode', $command);
+        return $command;
+    }
+
+    /**
+     * @depends testConstructorAcceptsServerMode
+     */
+    public function testConstructorSetsDefaultName(ReloadCommand $command)
+    {
+        $this->assertSame('reload', $command->getName());
+    }
+
+    /**
+     * @depends testConstructorAcceptsServerMode
+     */
+    public function testReloadCommandIsASymfonyConsoleCommand(ReloadCommand $command)
+    {
+        $this->assertInstanceOf(Command::class, $command);
+    }
+
+    /**
+     * @depends testConstructorAcceptsServerMode
+     */
+    public function testCommandDefinesNumWorkersOption(ReloadCommand $command)
+    {
+        $this->assertTrue($command->getDefinition()->hasOption('num-workers'));
+        return $command->getDefinition()->getOption('num-workers');
+    }
+
+    /**
+     * @depends testCommandDefinesNumWorkersOption
+     */
+    public function testNumWorkersOptionIsRequired(InputOption $option)
+    {
+        $this->assertTrue($option->isValueRequired());
+    }
+
+    /**
+     * @depends testCommandDefinesNumWorkersOption
+     */
+    public function testNumWorkersOptionDefinesShortOption(InputOption $option)
+    {
+        $this->assertSame('w', $option->getShortcut());
+    }
+
+    public function testExecuteEndsWithErrorWhenServerModeIsNotProcessMode()
+    {
+        $command = new ReloadCommand(SWOOLE_BASE);
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('not configured to run in SWOOLE_PROCESS mode'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testExecuteEndsWithErrorWhenStopCommandFails()
+    {
+        $command = new ReloadCommand(SWOOLE_PROCESS);
+
+        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand
+            ->run(
+                Argument::that(function ($arg) {
+                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
+                    TestCase::assertSame('stop', (string) $arg);
+                    return $arg;
+                }),
+                Argument::that([$this->output, 'reveal'])
+            )
+            ->willReturn(1);
+
+        $application = $this->mockApplication();
+        $application->find('stop')->will([$stopCommand, 'reveal']);
+
+        $command->setApplication($application->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Reloading server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Cannot reload server: unable to stop'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testExecuteEndsWithErrorWhenStartCommandFails()
+    {
+        $command = new ReloadCommand(SWOOLE_PROCESS);
+
+        $this->input->getOption('num-workers')->willReturn(5);
+
+        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand
+            ->run(
+                Argument::that(function ($arg) {
+                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
+                    TestCase::assertSame('stop', (string) $arg);
+                    return $arg;
+                }),
+                Argument::that([$this->output, 'reveal'])
+            )
+            ->willReturn(0);
+
+        $startCommand = $this->prophesize(Command::class);
+        $startCommand
+            ->run(
+                Argument::that(function ($arg) {
+                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
+                    TestCase::assertSame('start --daemonize=1 --num-workers=5', (string) $arg);
+                    return $arg;
+                }),
+                Argument::that([$this->output, 'reveal'])
+            )
+            ->willReturn(1);
+
+        $application = $this->mockApplication();
+        $application->find('stop')->will([$stopCommand, 'reveal']);
+        $application->find('start')->will([$startCommand, 'reveal']);
+
+        $command->setApplication($application->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Reloading server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->write(Argument::containingString('Waiting for 5 seconds'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->write(Argument::containingString('<info>.</info>'))
+            ->shouldHaveBeenCalledTimes(5);
+
+        $this->output
+            ->writeln(Argument::containingString('[DONE]'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Starting server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Cannot reload server: unable to start'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testExecuteEndsWithSuccessWhenBothStopAndStartCommandsSucceed()
+    {
+        $command = new ReloadCommand(SWOOLE_PROCESS);
+
+        $this->input->getOption('num-workers')->willReturn(5);
+
+        $stopCommand = $this->prophesize(Command::class);
+        $stopCommand
+            ->run(
+                Argument::that(function ($arg) {
+                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
+                    TestCase::assertSame('stop', (string) $arg);
+                    return $arg;
+                }),
+                Argument::that([$this->output, 'reveal'])
+            )
+            ->willReturn(0);
+
+        $startCommand = $this->prophesize(Command::class);
+        $startCommand
+            ->run(
+                Argument::that(function ($arg) {
+                    TestCase::assertInstanceOf(ArrayInput::class, $arg);
+                    TestCase::assertSame('start --daemonize=1 --num-workers=5', (string) $arg);
+                    return $arg;
+                }),
+                Argument::that([$this->output, 'reveal'])
+            )
+            ->willReturn(0);
+
+        $application = $this->mockApplication();
+        $application->find('stop')->will([$stopCommand, 'reveal']);
+        $application->find('start')->will([$startCommand, 'reveal']);
+
+        $command->setApplication($application->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Reloading server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->write(Argument::containingString('Waiting for 5 seconds'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->write(Argument::containingString('<info>.</info>'))
+            ->shouldHaveBeenCalledTimes(5);
+
+        $this->output
+            ->writeln(Argument::containingString('[DONE]'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Starting server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Cannot reload server'))
+            ->shouldNotHaveBeenCalled();
+    }
+}

--- a/test/Command/StartCommandFactoryTest.php
+++ b/test/Command/StartCommandFactoryTest.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\Command\StartCommand;
+use Zend\Expressive\Swoole\Command\StartCommandFactory;
+
+class StartCommandFactoryTest extends TestCase
+{
+    public function testFactoryProducesCommand()
+    {
+        $container = $this->prophesize(ContainerInterface::class)->reveal();
+
+        $factory = new StartCommandFactory();
+
+        $command = $factory($container);
+
+        $this->assertInstanceOf(StartCommand::class, $command);
+        $this->assertAttributeSame($container, 'container', $command);
+    }
+}

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ProphecyInterface;
+use Psr\Container\ContainerInterface;
+use Swoole\Http\Server as SwooleHttpServer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+use Zend\Expressive\Swoole\Command\StartCommand;
+use Zend\Expressive\Swoole\PidManager;
+
+use function getmypid;
+use function get_include_path;
+use function realpath;
+use function set_include_path;
+use function sprintf;
+
+use const PATH_SEPARATOR;
+
+class StartCommandTest extends TestCase
+{
+    use ReflectMethodTrait;
+
+    public function setUp()
+    {
+        $this->container  = $this->prophesize(ContainerInterface::class);
+        $this->input      = $this->prophesize(InputInterface::class);
+        $this->output     = $this->prophesize(OutputInterface::class);
+        $this->pidManager = $this->prophesize(PidManager::class);
+
+        $this->originalIncludePath = get_include_path();
+        set_include_path(sprintf(
+            '%s/TestAsset%s%s',
+            realpath(__DIR__),
+            PATH_SEPARATOR,
+            $this->originalIncludePath
+        ));
+    }
+
+    public function tearDown()
+    {
+        set_include_path($this->originalIncludePath);
+    }
+
+    public function pushServiceToContainer(string $name, $instance)
+    {
+        if ($instance instanceof ProphecyInterface) {
+            $instance = $instance->reveal();
+        }
+        $this->container->get($name)->willReturn($instance);
+    }
+
+    public function testConstructorAcceptsContainer()
+    {
+        $command = new StartCommand($this->container->reveal());
+        $this->assertAttributeSame($this->container->reveal(), 'container', $command);
+        return $command;
+    }
+
+    /**
+     * @depends testConstructorAcceptsContainer
+     */
+    public function testConstructorSetsDefaultName(StartCommand $command)
+    {
+        $this->assertSame('start', $command->getName());
+    }
+
+    /**
+     * @depends testConstructorAcceptsContainer
+     */
+    public function testStartCommandIsASymfonyConsoleCommand(StartCommand $command)
+    {
+        $this->assertInstanceOf(Command::class, $command);
+    }
+
+    /**
+     * @depends testConstructorAcceptsContainer
+     */
+    public function testCommandDefinesNumWorkersOption(StartCommand $command)
+    {
+        $this->assertTrue($command->getDefinition()->hasOption('num-workers'));
+        return $command->getDefinition()->getOption('num-workers');
+    }
+
+    /**
+     * @depends testCommandDefinesNumWorkersOption
+     */
+    public function testNumWorkersOptionIsRequired(InputOption $option)
+    {
+        $this->assertTrue($option->isValueRequired());
+    }
+
+    /**
+     * @depends testCommandDefinesNumWorkersOption
+     */
+    public function testNumWorkersOptionDefinesShortOption(InputOption $option)
+    {
+        $this->assertSame('w', $option->getShortcut());
+    }
+
+    /**
+     * @depends testConstructorAcceptsContainer
+     */
+    public function testCommandDefinesDaemonizeOption(StartCommand $command)
+    {
+        $this->assertTrue($command->getDefinition()->hasOption('daemonize'));
+        return $command->getDefinition()->getOption('daemonize');
+    }
+
+    /**
+     * @depends testCommandDefinesDaemonizeOption
+     */
+    public function testDaemonizeOptionHasNoValue(InputOption $option)
+    {
+        $this->assertFalse($option->acceptValue());
+    }
+
+    /**
+     * @depends testCommandDefinesDaemonizeOption
+     */
+    public function testDaemonizeOptionDefinesShortOption(InputOption $option)
+    {
+        $this->assertSame('d', $option->getShortcut());
+    }
+
+    public function testExecuteReturnsErrorIfServerIsRunningInBaseMode()
+    {
+        $this->pidManager->read()->willReturn([getmypid(), null]);
+        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+
+        $command = new StartCommand($this->container->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Server is already running'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function testExecuteReturnsErrorIfServerIsRunningInProcessMode()
+    {
+        $this->pidManager->read()->willReturn([1000000, getmypid()]);
+        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+
+        $command = new StartCommand($this->container->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Server is already running'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function noRunningProcesses() : iterable
+    {
+        yield 'empty'        => [[]];
+        yield 'null-all'     => [[null, null]];
+        yield 'base-mode'    => [[1000000, null]];
+        yield 'process-mode' => [[1000000, 1000001]];
+    }
+
+    /**
+     * @dataProvider noRunningProcesses
+     */
+    public function testExecuteRunsApplicationIfServerIsNotCurrentlyRunning(array $pids)
+    {
+        $this->input->getOption('daemonize')->willReturn(true);
+        $this->input->getOption('num-workers')->willReturn(6);
+
+        $this->pidManager->read()->willReturn($pids);
+        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
+
+        $httpServer = $this->prophesize(TestAsset\HttpServer::class);
+        $this->pushServiceToContainer(SwooleHttpServer::class, $httpServer);
+
+        $middlewareFactory = $this->prophesize(MiddlewareFactory::class);
+        $this->pushServiceToContainer(MiddlewareFactory::class, $middlewareFactory);
+
+        $application = $this->prophesize(Application::class);
+        $this->pushServiceToContainer(Application::class, $application);
+
+        $command = new StartCommand($this->container->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $httpServer
+            ->set(Argument::that(function ($options) {
+                TestCase::assertArrayHasKey('daemonize', $options);
+                TestCase::assertArrayHasKey('worker_num', $options);
+                TestCase::assertTrue($options['daemonize']);
+                TestCase::assertSame(6, $options['worker_num']);
+                return $options;
+            }))
+            ->shouldHaveBeenCalled();
+
+        $application->run()->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Server is already running'))
+            ->shouldNotHaveBeenCalled();
+    }
+}

--- a/test/Command/StatusCommandFactoryTest.php
+++ b/test/Command/StatusCommandFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\Command\StatusCommand;
+use Zend\Expressive\Swoole\Command\StatusCommandFactory;
+use Zend\Expressive\Swoole\PidManager;
+
+class StatusCommandFactoryTest extends TestCase
+{
+    public function testFactoryProducesCommand()
+    {
+        $pidManager = $this->prophesize(PidManager::class)->reveal();
+        $container  = $this->prophesize(ContainerInterface::class);
+        $container->get(PidManager::class)->willReturn($pidManager);
+
+        $factory = new StatusCommandFactory();
+
+        $command = $factory($container->reveal());
+
+        $this->assertInstanceOf(StatusCommand::class, $command);
+        $this->assertAttributeSame($pidManager, 'pidManager', $command);
+    }
+}

--- a/test/Command/StatusCommandTest.php
+++ b/test/Command/StatusCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Swoole\Command\StatusCommand;
+use Zend\Expressive\Swoole\PidManager;
+
+use function getmypid;
+
+class StatusCommandTest extends TestCase
+{
+    use ReflectMethodTrait;
+
+    public function setUp()
+    {
+        $this->input      = $this->prophesize(InputInterface::class);
+        $this->output     = $this->prophesize(OutputInterface::class);
+        $this->pidManager = $this->prophesize(PidManager::class);
+    }
+
+    public function testConstructorAcceptsPidManager()
+    {
+        $command = new StatusCommand($this->pidManager->reveal());
+        $this->assertAttributeSame($this->pidManager->reveal(), 'pidManager', $command);
+        return $command;
+    }
+
+    /**
+     * @depends testConstructorAcceptsPidManager
+     */
+    public function testConstructorSetsDefaultName(StatusCommand $command)
+    {
+        $this->assertSame('status', $command->getName());
+    }
+
+    /**
+     * @depends testConstructorAcceptsPidManager
+     */
+    public function testStatusCommandIsASymfonyConsoleCommand(StatusCommand $command)
+    {
+        $this->assertInstanceOf(Command::class, $command);
+    }
+
+    public function runningProcesses() : iterable
+    {
+        yield 'base-mode'    => [[getmypid(), null]];
+        yield 'process-mode' => [[1000000, getmypid()]];
+    }
+
+    /**
+     * @dataProvider runningProcesses
+     */
+    public function testExecuteIndicatesRunningServerWhenServerDetected(array $pids)
+    {
+        $this->pidManager->read()->willReturn($pids);
+
+        $command = new StatusCommand($this->pidManager->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Server is running'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function noRunningProcesses() : iterable
+    {
+        yield 'empty'        => [[]];
+        yield 'null-all'     => [[null, null]];
+        yield 'base-mode'    => [[1000000, null]];
+        yield 'process-mode' => [[1000000, 1000001]];
+    }
+
+    /**
+     * @dataProvider noRunningProcesses
+     */
+    public function testExecuteIndicatesNoRunningServerWhenServerNotDetected(array $pids)
+    {
+        $this->pidManager->read()->willReturn($pids);
+
+        $command = new StatusCommand($this->pidManager->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Server is not running'))
+            ->shouldHaveBeenCalled();
+    }
+}

--- a/test/Command/StopCommandFactoryTest.php
+++ b/test/Command/StopCommandFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Swoole\Command\StopCommand;
+use Zend\Expressive\Swoole\Command\StopCommandFactory;
+use Zend\Expressive\Swoole\PidManager;
+
+class StopCommandFactoryTest extends TestCase
+{
+    public function testFactoryProducesCommand()
+    {
+        $pidManager = $this->prophesize(PidManager::class)->reveal();
+        $container  = $this->prophesize(ContainerInterface::class);
+        $container->get(PidManager::class)->willReturn($pidManager);
+
+        $factory = new StopCommandFactory();
+
+        $command = $factory($container->reveal());
+
+        $this->assertInstanceOf(StopCommand::class, $command);
+        $this->assertAttributeSame($pidManager, 'pidManager', $command);
+    }
+}

--- a/test/Command/StopCommandTest.php
+++ b/test/Command/StopCommandTest.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command;
+
+use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Swoole\Process as SwooleProcess;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Zend\Expressive\Swoole\Command\StopCommand;
+use Zend\Expressive\Swoole\PidManager;
+
+use function getmypid;
+
+class StopCommandTest extends TestCase
+{
+    use ReflectMethodTrait;
+
+    public function setUp()
+    {
+        $this->input      = $this->prophesize(InputInterface::class);
+        $this->output     = $this->prophesize(OutputInterface::class);
+        $this->pidManager = $this->prophesize(PidManager::class);
+    }
+
+    public function testConstructorAcceptsPidManager()
+    {
+        $command = new StopCommand($this->pidManager->reveal());
+        $this->assertAttributeSame($this->pidManager->reveal(), 'pidManager', $command);
+        return $command;
+    }
+
+    /**
+     * @depends testConstructorAcceptsPidManager
+     */
+    public function testConstructorSetsDefaultName(StopCommand $command)
+    {
+        $this->assertSame('stop', $command->getName());
+    }
+
+    /**
+     * @depends testConstructorAcceptsPidManager
+     */
+    public function testStopCommandIsASymfonyConsoleCommand(StopCommand $command)
+    {
+        $this->assertInstanceOf(Command::class, $command);
+    }
+
+    public function noRunningProcesses() : iterable
+    {
+        yield 'empty'        => [[]];
+        yield 'null-all'     => [[null, null]];
+        yield 'base-mode'    => [[1000000, null]];
+        yield 'process-mode' => [[1000000, 1000001]];
+    }
+
+    /**
+     * @dataProvider noRunningProcesses
+     */
+    public function testExecuteReturnsSuccessWhenServerIsNotCurrentlyRunning(array $pids)
+    {
+        $this->pidManager->read()->willReturn($pids);
+
+        $command = new StopCommand($this->pidManager->reveal());
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->output
+            ->writeln(Argument::containingString('Server is not running'))
+            ->shouldHaveBeenCalled();
+    }
+
+    public function runningProcesses() : iterable
+    {
+        yield 'base-mode'    => [[getmypid(), null]];
+        yield 'process-mode' => [[1000000, getmypid()]];
+    }
+
+    /**
+     * @dataProvider runningProcesses
+     */
+    public function testExecuteReturnsErrorIfUnableToStopServer(array $pids)
+    {
+        $this->pidManager->read()->willReturn($pids);
+
+        $masterPid   = $pids[0];
+        $spy         = (object) ['called' => false];
+        $killProcess = function (int $pid, int $signal = null) use ($masterPid, $spy) {
+            TestCase::assertSame($masterPid, $pid);
+            $spy->called = true;
+            return $signal === 0;
+        };
+
+        $command = new StopCommand($this->pidManager->reveal());
+        $command->killProcess = $killProcess;
+        $command->waitThreshold = 1;
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(1, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->assertTrue($spy->called);
+
+        $this->pidManager->delete()->shouldNotHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Stopping server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Error stopping server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Server stopped'))
+            ->shouldNotHaveBeenCalled();
+    }
+
+    /**
+     * @dataProvider runningProcesses
+     */
+    public function testExecuteReturnsSuccessIfAbleToStopServer(array $pids)
+    {
+        $this->pidManager->read()->willReturn($pids);
+        $this->pidManager->delete()->shouldBeCalled();
+
+        $masterPid   = $pids[0];
+        $spy         = (object) ['called' => false];
+        $killProcess = function (int $pid) use ($masterPid, $spy) {
+            TestCase::assertSame($masterPid, $pid);
+            $spy->called = true;
+            return true;
+        };
+
+        $command = new StopCommand($this->pidManager->reveal());
+        $command->killProcess = $killProcess;
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+
+        $this->assertTrue($spy->called);
+
+        $this->output
+            ->writeln(Argument::containingString('Stopping server'))
+            ->shouldHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Error stopping server'))
+            ->shouldNotHaveBeenCalled();
+
+        $this->output
+            ->writeln(Argument::containingString('Server stopped'))
+            ->shouldHaveBeenCalled();
+    }
+}

--- a/test/Command/TestAsset/HttpServer.php
+++ b/test/Command/TestAsset/HttpServer.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\Command\TestAsset;
+
+/**
+ * Dummy interface defining the HTTP server.
+ *
+ * For purposes of testing, we only need to pull the server from the container
+ * and then call its `set()` method. Unfortunately, Swoole\Http\Server is not
+ * mockable (for some reason, mocks of the class do not end up with the same
+ * typehints for arguments as the actual class, leading to errors), we can
+ * leverage the fact that the container doesn't care what instance is returned,
+ * and the code does not verify the type.
+ */
+interface HttpServer
+{
+    public function set(array $options) : void;
+}

--- a/test/Command/TestAsset/config/pipeline.php
+++ b/test/Command/TestAsset/config/pipeline.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) {
+};

--- a/test/Command/TestAsset/config/routes.php
+++ b/test/Command/TestAsset/config/routes.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+use Psr\Container\ContainerInterface;
+use Zend\Expressive\Application;
+use Zend\Expressive\MiddlewareFactory;
+
+return function (Application $app, MiddlewareFactory $factory, ContainerInterface $container) {
+};

--- a/test/SwooleRequestHandlerRunnerTest.php
+++ b/test/SwooleRequestHandlerRunnerTest.php
@@ -72,13 +72,16 @@ class SwooleRequestHandlerRunnerTest extends TestCase
 
     public function testRun()
     {
-        $this->pidManager->read()
-            ->willReturn([null, null]);
+        $this->pidManager
+            ->read()
+            ->willReturn([]);
 
-        $this->httpServer->method('on')
+        $this->httpServer
+            ->method('on')
             ->willReturn(null);
 
-        $this->httpServer->method('start')
+        $this->httpServer
+            ->method('start')
             ->willReturn(null);
 
         $this->staticResourceHandler
@@ -94,24 +97,19 @@ class SwooleRequestHandlerRunnerTest extends TestCase
             $this->staticResourceHandler->reveal(),
             $this->logger
         );
-        $requestHandler->exitFromCommand = false;
 
-        $this->httpServer->expects($this->once())
+        $this->httpServer
+            ->expects($this->once())
             ->method('start');
 
         // Listeners are attached to each of:
         // - start
         // - workerstart
         // - request
-        $this->httpServer->expects($this->exactly(3))
+        $this->httpServer
+            ->expects($this->exactly(3))
             ->method('on');
 
-        // Clear command options, like phpunit --colors=always
-        $_SERVER['argv'] = [
-            $_SERVER['argv'][0],
-            'start'
-        ];
-        $_SERVER['argc'] = 2;
         $requestHandler->run();
     }
 


### PR DESCRIPTION
A problem we were observing is that if we want access to the HTTP server for the purpose of registering task workers, triggering tasks, etc., we MUST be able to compose the HTTP server directly in the HTTP runner.  However, if the commands are run via the HTTP runner, the server is already present, and we cannot do things such as restart the server.

This patch thus moves the CLI tooling out of the runner, and creates a vendor binary, `zend-expressive-swoole`. One nice aspect of this is that `reload` now properly reloads the entire application, allowing it to pick up code, configuration, and other changes.

I've also taken the liberty of adding a `status` command, to determine whether or not the server is currently running.

The downside of this is that it cannot pick up changes to the workflow of `public/index.php`. As such, if users want to change that, they will need to do it in either `config/routes.php`, `config/pipeline.php`, or in their own command line tooling.