### PR TITLE
Static resource handler switch - WIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,21 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#50](https://github.com/zendframework/zend-expressive-swoole/pull/50) adds a new configuration flag for toggling serving of static files:
+  `zend-expressive-swoole.swoole-http-server.static-files.enable`. The flag is
+  enabled by default; set it to boolean `false` to disable static file serving:
+
+  ```php
+  return [
+      'zend-expressive-swoole' => [
+          'swoole-http-server' => [
+              'static-files' => [
+                  'enable' => false,
+              ],
+          ],
+      ],
+  ];
+  ```
 
 ### Changed
 

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -40,6 +40,9 @@ class ConfigProvider
                     // and set a production value to match.
                     'max_conn' => 1024,
                 ],
+                'static-files' => [
+                    'enable' => true,
+                ],
             ],
         ];
     }
@@ -56,11 +59,12 @@ class ConfigProvider
                 PidManager::class                     => PidManagerFactory::class,
                 SwooleRequestHandlerRunner::class     => SwooleRequestHandlerRunnerFactory::class,
                 ServerRequestInterface::class         => ServerRequestSwooleFactory::class,
-                StaticResourceHandlerInterface::class => StaticResourceHandlerFactory::class,
+                StaticResourceHandler::class          => StaticResourceHandlerFactory::class,
                 SwooleHttpServer::class               => HttpServerFactory::class,
             ],
             'aliases' => [
                 RequestHandlerRunner::class           => SwooleRequestHandlerRunner::class,
+                StaticResourceHandlerInterface::class => StaticResourceHandler::class,
             ],
             'delegators' => [
                 'Zend\Expressive\WhoopsPageHandler' => [

--- a/src/SwooleRequestHandlerRunnerFactory.php
+++ b/src/SwooleRequestHandlerRunnerFactory.php
@@ -19,9 +19,6 @@ class SwooleRequestHandlerRunnerFactory
 {
     public function __invoke(ContainerInterface $container) : SwooleRequestHandlerRunner
     {
-        $staticResourceHandler = $container->has(StaticResourceHandlerInterface::class)
-            ? $container->get(StaticResourceHandlerInterface::class)
-            : null;
         $logger = $container->has(Log\AccessLogInterface::class)
             ? $container->get(Log\AccessLogInterface::class)
             : null;
@@ -32,8 +29,18 @@ class SwooleRequestHandlerRunnerFactory
             $container->get(ServerRequestErrorResponseGenerator::class),
             $container->get(PidManager::class),
             $container->get(SwooleHttpServer::class),
-            $staticResourceHandler,
+            $this->retrieveStaticResourceHandler($container),
             $logger
         );
+    }
+
+    private function retrieveStaticResourceHandler(ContainerInterface $container) :? StaticResourceHandlerInterface
+    {
+        $config = $container->get('config')['zend-expressive-swoole']['swoole-http-server']['static-files'];
+        $enabled = isset($config['enable']) && true === $config['enable'];
+        if ($enabled && $container->has(StaticResourceHandlerInterface::class)) {
+            return $container->get(StaticResourceHandlerInterface::class);
+        }
+        return null;
     }
 }

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -80,9 +80,7 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
             ->willReturn([
                 'zend-expressive-swoole' => [
                     'swoole-http-server' => [
-                        'static-files' => [
-
-                        ],
+                        'static-files' => [],
                     ],
                 ],
             ]);
@@ -151,5 +149,33 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
         $runner = $factory($this->container->reveal());
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
         $this->assertAttributeSame($this->staticResourceHandler->reveal(), 'staticResourceHandler', $runner);
+    }
+
+    public function testFactoryWillIgnoreConfiguredStaticResourceHandlerWhenStaticFilesAreDisabled()
+    {
+        $this->configureAbsentLoggerService();
+        $this->container
+            ->has(StaticResourceHandlerInterface::class)
+            ->willReturn(true);
+        $this->container
+            ->get('config')
+            ->willReturn([
+                'zend-expressive-swoole' => [
+                    'swoole-http-server' => [
+                        'static-files' => [
+                            'enable' => false, // Disabling static files
+                        ],
+                    ],
+                ],
+            ]);
+
+        $factory = new SwooleRequestHandlerRunnerFactory();
+        $runner = $factory($this->container->reveal());
+
+        $this->container
+            ->get(StaticResourceHandlerInterface::class)
+            ->shouldNotHaveBeenCalled();
+        $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
+        $this->assertAttributeEmpty('staticResourceHandler', $runner);
     }
 }

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -74,6 +74,18 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
         $this->container
             ->get(StaticResourceHandlerInterface::class)
             ->shouldNotBeCalled();
+
+        $this->container
+            ->get('config')
+            ->willReturn([
+                'zend-expressive-swoole' => [
+                    'swoole-http-server' => [
+                        'static-files' => [
+
+                        ],
+                    ],
+                ],
+            ]);
     }
 
     public function configureAbsentLoggerService()
@@ -123,6 +135,17 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
         $this->container
             ->get(StaticResourceHandlerInterface::class)
             ->will([$this->staticResourceHandler, 'reveal']);
+        $this->container
+            ->get('config')
+            ->willReturn([
+                'zend-expressive-swoole' => [
+                    'swoole-http-server' => [
+                        'static-files' => [
+                            'enable' => true,
+                        ],
+                    ],
+                ],
+            ]);
 
         $factory = new SwooleRequestHandlerRunnerFactory();
         $runner = $factory($this->container->reveal());


### PR DESCRIPTION
With reference to #49 - It should be easier to disable the serving of static files. Before this change, I'm assuming that you'd need to overwrite the container configuration with a factory designed to return a `null` for the Static Resource Handler, or modify the container configuration at runtime (??)
This 'switch' preserves current behaviour whilst allowing an easier way to disable serving of static files.
If this is a potential solution for #49 I'll update docs and add tests.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

