### PR TITLE
Feature/fix programmatic config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ All notable changes to this project will be documented in this file, in reverse 
 - [#48](https://github.com/zendframework/zend-expressive-swoole/pull/48) adds a `shutdown` handler to the Swoole HTTP server that clears the PID
   manager, ensuring the PID file is cleared.
 
+- [#52](https://github.com/zendframework/zend-expressive-swoole/pull/52) fixes an error thrown by the `start` command when using this component in
+  configuration-driven expressive applications, due to the fact that the command
+  always tried to require the `config/pipeline.php` and `config/routes.php`
+  files.
+
 ## 2.0.0 - 2018-11-15
 
 ### Added

--- a/test/Command/StartCommandTest.php
+++ b/test/Command/StartCommandTest.php
@@ -240,19 +240,7 @@ class StartCommandTest extends TestCase
         $this->input->getOption('daemonize')->willReturn(false);
         $this->input->getOption('num-workers')->willReturn(null);
 
-        $this->pidManager->read()->willReturn($pids);
-        $this->pushServiceToContainer(PidManager::class, $this->pidManager);
-
-        $httpServer = $this->prophesize(TestAsset\HttpServer::class);
-        $this->pushServiceToContainer(SwooleHttpServer::class, $httpServer);
-
-        $middlewareFactory = $this->prophesize(MiddlewareFactory::class);
-        $this->pushServiceToContainer(MiddlewareFactory::class, $middlewareFactory);
-
-        $application = $this->prophesize(Application::class);
-        $this->pushServiceToContainer(Application::class, $application);
-
-        $command = new StartCommand($this->container->reveal());
+        [$command, $httpServer, $application] = $this->prepareSuccessfulStartCommand($pids);
 
         $execute = $this->reflectMethod($command, 'execute');
 
@@ -279,7 +267,20 @@ class StartCommandTest extends TestCase
     {
         set_include_path($this->originalIncludePath);
 
-        $this->pidManager->read()->willReturn([]);
+        [$command] = $this->prepareSuccessfulStartCommand([]);
+
+        $execute = $this->reflectMethod($command, 'execute');
+
+        $this->assertSame(0, $execute->invoke(
+            $command,
+            $this->input->reveal(),
+            $this->output->reveal()
+        ));
+    }
+
+    private function prepareSuccessfulStartCommand(array $pids) : array
+    {
+        $this->pidManager->read()->willReturn($pids);
         $this->pushServiceToContainer(PidManager::class, $this->pidManager);
 
         $httpServer = $this->prophesize(TestAsset\HttpServer::class);
@@ -293,12 +294,6 @@ class StartCommandTest extends TestCase
 
         $command = new StartCommand($this->container->reveal());
 
-        $execute = $this->reflectMethod($command, 'execute');
-
-        $this->assertSame(0, $execute->invoke(
-            $command,
-            $this->input->reveal(),
-            $this->output->reveal()
-        ));
+        return [$command, $httpServer, $application];
     }
 }


### PR DESCRIPTION
This fixes an error thrown by the `StartCommand` when trying to add this component to config-driven expressive applications. The bug was reported in #51. 

Previously the command always tried to require the `config/pipeline.php` and `config/routes.php` files. Now, it does it dynamically, by checking if those files exist first.