### PR TITLE
Set process names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#54](https://github.com/zendframework/zend-expressive-swoole/pull/54) adds a new configuration key, `zend-expressive-swoole.swoole-http-server.process-name`.
+  This value will be used as a prefix for the process name of all processes
+  created by the `Swoole\Http\Server` instance, including the master process,
+  worker processes, and all task worker processes. The value defaults to
+  `expressive`. As an example:
+
+  ```php
+  return [
+      'zend-expressive-swoole' => [
+          'swoole-http-server' => [
+              'process-name' => 'myapp',
+          ],
+      ],
+  ];
+  ```
+
 - [#50](https://github.com/zendframework/zend-expressive-swoole/pull/50) adds a new configuration flag for toggling serving of static files:
   `zend-expressive-swoole.swoole-http-server.static-files.enable`. The flag is
   enabled by default; set it to boolean `false` to disable static file serving:

--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -112,6 +112,12 @@ return [
                 // enabled by default, and generally should not be disabled:
                 'enable_coroutine' => true,
             ],
+
+            // Since 2.1.0: Set the process name prefix.
+            // The master process will be named `{prefix}-master`,
+            // worker processes will be named `{prefix}-worker-{id}`,
+            // and task worker processes will be named `{prefix}-task-worker-{id}`
+            'process-name' => 'your-app',
         ],
     ],
 ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -31,6 +31,11 @@ class ConfigProvider
     {
         return [
             'swoole-http-server' => [
+                // A prefix for the process name of the master process and workers.
+                // By default the master process will be named `expressive-master`,
+                // each http worker `expressive-worker-n` and each task worker
+                // `expressive-task-worker-n` where n is the id of the worker
+                'process-name' => 'expressive',
                 'options' => [
                     // We set a default for this. Without one, Swoole\Http\Server
                     // defaults to the value of `ulimit -n`. Unfortunately, in

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -15,16 +15,10 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Swoole\Http\Request as SwooleHttpRequest;
 use Swoole\Http\Response as SwooleHttpResponse;
 use Swoole\Http\Server as SwooleHttpServer;
-use Swoole\Process as SwooleProcess;
 use Throwable;
 use Zend\Expressive\Swoole\Exception;
 use Zend\HttpHandlerRunner\Emitter\EmitterInterface;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
-
-use function date;
-use function microtime;
-use function time;
-use function usleep;
 use function swoole_set_process_name;
 use const PHP_OS;
 

--- a/src/SwooleRequestHandlerRunnerFactory.php
+++ b/src/SwooleRequestHandlerRunnerFactory.php
@@ -39,8 +39,10 @@ class SwooleRequestHandlerRunnerFactory
         );
     }
 
-    private function retrieveStaticResourceHandler(ContainerInterface $container, array $config) : ?StaticResourceHandlerInterface
-    {
+    private function retrieveStaticResourceHandler(
+        ContainerInterface $container,
+        array $config
+    ) : ?StaticResourceHandlerInterface {
         $config = $config['static-files'] ?? [];
         $enabled = isset($config['enable']) && true === $config['enable'];
 

--- a/src/SwooleRequestHandlerRunnerFactory.php
+++ b/src/SwooleRequestHandlerRunnerFactory.php
@@ -23,24 +23,29 @@ class SwooleRequestHandlerRunnerFactory
             ? $container->get(Log\AccessLogInterface::class)
             : null;
 
+        $config = $container->has('config')
+            ? $container->get('config')['zend-expressive-swoole']['swoole-http-server']
+            : [];
+
         return new SwooleRequestHandlerRunner(
             $container->get(ApplicationPipeline::class),
             $container->get(ServerRequestInterface::class),
             $container->get(ServerRequestErrorResponseGenerator::class),
             $container->get(PidManager::class),
             $container->get(SwooleHttpServer::class),
-            $this->retrieveStaticResourceHandler($container),
-            $logger
+            $this->retrieveStaticResourceHandler($container, $config),
+            $logger,
+            $config['process-name'] ?? SwooleRequestHandlerRunner::DEFAULT_PROCESS_NAME
         );
     }
 
-    private function retrieveStaticResourceHandler(ContainerInterface $container) :? StaticResourceHandlerInterface
+    private function retrieveStaticResourceHandler(ContainerInterface $container, array $config) : ?StaticResourceHandlerInterface
     {
-        $config = $container->get('config')['zend-expressive-swoole']['swoole-http-server']['static-files'];
+        $config = $config['static-files'] ?? [];
         $enabled = isset($config['enable']) && true === $config['enable'];
-        if ($enabled && $container->has(StaticResourceHandlerInterface::class)) {
-            return $container->get(StaticResourceHandlerInterface::class);
-        }
-        return null;
+
+        return $enabled && $container->has(StaticResourceHandlerInterface::class)
+            ? $container->get(StaticResourceHandlerInterface::class)
+            : null;
     }
 }

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -97,10 +97,22 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
             ->shouldNotBeCalled();
     }
 
+    public function configureAbsentConfiguration() : void
+    {
+        $this->container
+            ->has('config')
+            ->willReturn(false);
+
+        $this->container
+            ->get('config')
+            ->shouldNotBeCalled();
+    }
+
     public function testInvocationWithoutOptionalServicesConfiguresInstanceWithDefaults()
     {
         $this->configureAbsentStaticResourceHandler();
         $this->configureAbsentLoggerService();
+        $this->configureAbsentConfiguration();
         $factory = new SwooleRequestHandlerRunnerFactory();
         $runner = $factory($this->container->reveal());
         $this->assertInstanceOf(SwooleRequestHandlerRunner::class, $runner);
@@ -111,6 +123,7 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
     public function testFactoryWillUseConfiguredPsr3LoggerWhenPresent()
     {
         $this->configureAbsentStaticResourceHandler();
+        $this->configureAbsentConfiguration();
         $this->container
             ->has(AccessLogInterface::class)
             ->willReturn(true);
@@ -127,6 +140,7 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
     public function testFactoryWillUseConfiguredStaticResourceHandlerWhenPresent()
     {
         $this->configureAbsentLoggerService();
+        $this->configureAbsentConfiguration();
         $this->container
             ->has(StaticResourceHandlerInterface::class)
             ->willReturn(true);

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -140,13 +140,13 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
     public function testFactoryWillUseConfiguredStaticResourceHandlerWhenPresent()
     {
         $this->configureAbsentLoggerService();
-        $this->configureAbsentConfiguration();
         $this->container
             ->has(StaticResourceHandlerInterface::class)
             ->willReturn(true);
         $this->container
             ->get(StaticResourceHandlerInterface::class)
             ->will([$this->staticResourceHandler, 'reveal']);
+        $this->container->has('config')->willReturn(true);
         $this->container
             ->get('config')
             ->willReturn([
@@ -171,6 +171,7 @@ class SwooleRequestHandlerRunnerFactoryTest extends TestCase
         $this->container
             ->has(StaticResourceHandlerInterface::class)
             ->willReturn(true);
+        $this->container->has('config')->willReturn(true);
         $this->container
             ->get('config')
             ->willReturn([


### PR DESCRIPTION
If you are running more than one expressive-swoole app on the same server, it gets very difficult to tell processes apart and also to identify the master and worker processes. This feature provides a default "prefix" for process names of "expressive" providing the host OS isn't a Mac, and lets users configure that prefix.

I don't know of any portable way to test this feature. On linux, I've found that `trim(file_get_contents("/proc/{process-id}/cmdline"), "\0")` reports the expected values but I don't know how that will work in CI and tests would fail, or need to be skipped on certain OS's.

Seeing as the request handler runner needs the on('start') and on('workerstart') callbacks, it seems sensible to do this here(?)

If this is an acceptable idea, I'll add docs of course.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.
