### PR TITLE
Added support to configure custom logger service

### DIFF
--- a/docs/book/v2/logging.md
+++ b/docs/book/v2/logging.md
@@ -124,20 +124,29 @@ If you are using a [PSR-11](https://www.php-fig.org/psr/psr-11/) container, the
 
 You have two options for substituting your own logger from there.
 
-First, you can create your own factory that produces an `AccessLogInterface`
-instance, and map it to the service. This is the best route if you want to write
-your own implementation, or want to use a different PSR-3 logger service.
+First, if you already have a service which resolves to a `Psr\Log\LoggerInterface` instance,
+you can configure it by providing its name:
 
-If you are okay with re-using your existing PSR-3 logger, the provided
-`Zend\Expressive\Swoole\Log\AccessLogFactory` will use the
-`Psr\Log\LoggerInterface` service to create a `Psr3AccessLogDecorator` instance.
+```php
+'zend-expressive-swoole' => [
+    'swoole-http-server' => [
+        'logger' => [
+            'logger-name' => 'my_logger', // define the logger service name here
+        ],
+    ],
+],
+```
+
+If you don't want to manually provide the service name but you are okay with re-using your
+existing PSR-3 logger, the provided `Zend\Expressive\Swoole\Log\AccessLogFactory` will use
+the `Psr\Log\LoggerInterface` service to create a `Psr3AccessLogDecorator` instance.
 
 This factory also allows you to specify a custom `AccessLogFormatterInterface`
 instance if you want. It will look up a service by the fully-qualified interface
 name, and use it if present. Otherwise, it creates an `AccessLogFormatter`
 instance for you.
 
-The factory will also look at the following configuration values:
+In both cases the factory will also look at the following configuration values:
 
 ```php
 'zend-expressive-swoole' => [

--- a/src/Log/AccessLogFactory.php
+++ b/src/Log/AccessLogFactory.php
@@ -23,6 +23,7 @@ use Psr\Log\LoggerInterface;
  * 'zend-expressive-swoole' => [
  *     'swoole-http-server' => [
  *         'logger' => [
+ *             'logger-name' => string, // the name of a service resolving a Psr\Log\LoggerInterface instance
  *             'format' => string, // one of the AccessLogFormatter::FORMAT_* constants
  *             'use-hostname-lookups' => bool, // Set to true to enable hostname lookups
  *         ],
@@ -38,10 +39,19 @@ class AccessLogFactory
         $config = $config['zend-expressive-swoole']['swoole-http-server']['logger'] ?? [];
 
         return new Psr3AccessLogDecorator(
-            $container->has(LoggerInterface::class) ? $container->get(LoggerInterface::class) : new StdoutLogger(),
+            $this->getLogger($container, $config),
             $this->getFormatter($container, $config),
             $config['use-hostname-lookups'] ?? false
         );
+    }
+
+    private function getLogger(ContainerInterface $container, array $config) : LoggerInterface
+    {
+        if (isset($config['logger-name'])) {
+            return $container->get($config['logger-name']);
+        }
+
+        return $container->has(LoggerInterface::class) ? $container->get(LoggerInterface::class) : new StdoutLogger();
     }
 
     private function getFormatter(ContainerInterface $container, array $config) : AccessLogFormatterInterface


### PR DESCRIPTION
This provides the feature discussed in #53, allowing a custom logger service name to be provided in order to wrap it in the `Psr3AccessLogDecorator` service.

The service name has to be configured under the `zend-expressive-swoole.swoole-http-server.logger.logger-name` key, like this:

```php
'zend-expressive-swoole' => [
    'swoole-http-server' => [
        'logger' => [
            'logger-name' => 'my_logger', // define the logger service name here
        ],
    ],
],
```

If that config key is not provided, the factory keeps behaviong the same, trying to fetch the `Psr\Log\LoggerInterface` service, and falling back to a `Zend\Expressive\Swoole\Log\StdoutLogger` instance.