### PR TITLE
Added pid_file swoole option to additional config example

### DIFF
--- a/docs/book/v2/intro.md
+++ b/docs/book/v2/intro.md
@@ -111,6 +111,10 @@ return [
                 // Whether or not the HTTP server should use coroutines;
                 // enabled by default, and generally should not be disabled:
                 'enable_coroutine' => true,
+
+                // Overwrite the default location of the pid file;
+                // required when you want to run multiple instances of your service in different ports:
+                'pid_file' => 'path/to/pid_file.pid',
             ],
 
             // Since 2.1.0: Set the process name prefix.


### PR DESCRIPTION
This documents how to use the `zend-expressive-swoole.swoole-http-server.options.pid_file` config option to overwrite the default pid file in order to be able to run multiple instances of the service at the same time.

Ref #58 
