### PR TITLE
Added hot code reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Added
 
 - [#60](https://github.com/zendframework/zend-expressive-swoole/pull/60) adds a new configuration, `zend-expressive-swoole.hot-code-reload`.
-  Configuring hot-code-reload will allow swoole server to monitor for changes in included php files, and reload accordingly.
+  Configuring hot-code-reload allows the Swoole HTTP server to monitor for
+  changes in included PHP files, and reload accordingly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#60](https://github.com/zendframework/zend-expressive-swoole/pull/60) adds a new configuration, `zend-expressive-swoole.hot-code-reload`.
+  Configuring hot-code-reload will allow swoole server to monitor for changes in included php files, and reload accordingly.
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,9 @@
         "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-servicemanager": "^3.3"
     },
+    "suggest": {
+        "ext-inotify": "To use inotify based file watcher. Required for hot code reloading."
+    },
     "autoload": {
         "psr-4": {
             "Zend\\Expressive\\Swoole\\": "src/"

--- a/docs/book/v2/hot-code-reload.md
+++ b/docs/book/v2/hot-code-reload.md
@@ -1,19 +1,24 @@
 # Hot Code Reload
 
-To ease development when using swoole server, hot code reload can be enabled.
+> - Since 2.3.0
 
-With this feature enabled, a swoole worker will monitor included PHP files using inotify, and will restart all workers
-if a file is changed, thus mitigating the need to manually restart the server to "view" changes made.
+To ease development against a running Swoole HTTP server, hot code reloading can
+be enabled.
 
-**This feature should only be used in your local development environment, and should not be used in production!**
+With this feature enabled, a Swoole worker will monitor included PHP files using
+`inotify`, and will restart all workers if a file is changed, thus mitigating
+the need to manually restart the server to test changes.
+
+**This feature should only be used in your local development environment, and
+should not be used in production!**
 
 ## Requirements
 
-* `ext-inotify`
+- `ext-inotify`
 
-This library ships with an [inotify](http://php.net/manual/en/book.inotify.php) based implementation of 
-`\Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface`. In order to use it, the `inotify` extension must be
-loaded.
+This library ships with an [inotify](http://php.net/manual/en/book.inotify.php)
+based implementation of `Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface`.
+In order to use it, the `inotify` extension must be loaded.
 
 ## Configuration
 
@@ -25,8 +30,7 @@ The following demonstrates all currently available configuration options:
 return [
     'zend-expressive-swoole' => [
         'hot-code-reload' => [
-            // Since 2.3.0: Set to true to enable hot code reload.
-            // This is false by default.
+            // Set to true to enable hot code reload; the default is false.
             'enable' => true,
             
             // Time in milliseconds between checks to changes in files.
@@ -38,9 +42,14 @@ return [
 
 ## Limitations
 
-Only files included by php after `onWorkerStart` will be reloaded.
-The reloaded swoole server will not pick up added routes or pipeline middleware, nor changes to the server or
-Application instances.
+Only files included by PHP after `onWorkerStart` will be reloaded. This means
+that Swoole will not reload any of the following:
 
-This limitation exists because the hot code reloaded uses the `Swoole\Server::reload` method to signal swoole to reload
-php files (see https://www.swoole.co.uk/docs/modules/swoole-server-methods#public-boolean-swoole-server-reload-void).
+- New routes
+- New pipeline middleware
+- The `Application` instance, _or any delegators used to modify it_.
+- The Swoole HTTP server itself.
+
+This limitation exists because the hot code reload features use the
+`Swoole\Server::reload()` method to notify Swoole to reload
+PHP files (see [the Swoole reload() documentation for more details](https://www.swoole.co.uk/docs/modules/swoole-server-methods#public-boolean-swoole-server-reload-void)).

--- a/docs/book/v2/hot-code-reload.md
+++ b/docs/book/v2/hot-code-reload.md
@@ -1,0 +1,46 @@
+# Hot Code Reload
+
+To ease development when using swoole server, hot code reload can be enabled.
+
+With this feature enabled, a swoole worker will monitor included PHP files using inotify, and will restart all workers
+if a file is changed, thus mitigating the need to manually restart the server to "view" changes made.
+
+**This feature should only be used in your local development environment, and should not be used in production!**
+
+## Requirements
+
+* `ext-inotify`
+
+This library ships with an [inotify](http://php.net/manual/en/book.inotify.php) based implementation of 
+`\Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface`. In order to use it, the `inotify` extension must be
+loaded.
+
+## Configuration
+
+The following demonstrates all currently available configuration options:
+
+```php
+// config/autoload/swoole.local.php
+
+return [
+    'zend-expressive-swoole' => [
+        'hot-code-reload' => [
+            // Since 2.3.0: Set to true to enable hot code reload.
+            // This is false by default.
+            'enable' => true,
+            
+            // Time in milliseconds between checks to changes in files.
+            'interval' => 500,
+        ],
+    ],
+];
+```
+
+## Limitations
+
+Only files included by php after `onWorkerStart` will be reloaded.
+The reloaded swoole server will not pick up added routes or pipeline middleware, nor changes to the server or
+Application instances.
+
+This limitation exists because the hot code reloaded uses the `Swoole\Server::reload` method to signal swoole to reload
+php files (see https://www.swoole.co.uk/docs/modules/swoole-server-methods#public-boolean-swoole-server-reload-void).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ pages:
       - "Static Resources": v2/static-resources.md
       - Logging: v2/logging.md
       - "Async Tasks": v2/async-tasks.md
+      - "Hot Code Reloading": v2/hot-code-reload.md
       - "Command Line Tooling": v2/command-line.md
       - "How it works": v2/how-it-works.md
       - "Considerations when using Swoole": v2/considerations.md

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -11,6 +11,10 @@ namespace Zend\Expressive\Swoole;
 
 use Psr\Http\Message\ServerRequestInterface;
 use Swoole\Http\Server as SwooleHttpServer;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface;
+use Zend\Expressive\Swoole\HotCodeReload\Reloader;
+use Zend\Expressive\Swoole\HotCodeReload\ReloaderFactory;
 use Zend\HttpHandlerRunner\RequestHandlerRunner;
 use function extension_loaded;
 
@@ -66,10 +70,12 @@ class ConfigProvider
                 ServerRequestInterface::class         => ServerRequestSwooleFactory::class,
                 StaticResourceHandler::class          => StaticResourceHandlerFactory::class,
                 SwooleHttpServer::class               => HttpServerFactory::class,
+                Reloader::class                       => ReloaderFactory::class,
             ],
             'aliases' => [
                 RequestHandlerRunner::class           => SwooleRequestHandlerRunner::class,
                 StaticResourceHandlerInterface::class => StaticResourceHandler::class,
+                FileWatcherInterface::class           => InotifyFileWatcher::class,
             ],
             'delegators' => [
                 'Zend\Expressive\WhoopsPageHandler' => [

--- a/src/Exception/ExtensionNotLoadedException.php
+++ b/src/Exception/ExtensionNotLoadedException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\Exception;
+
+class ExtensionNotLoadedException extends RuntimeException
+{
+}

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -12,6 +12,7 @@ namespace Zend\Expressive\Swoole\HotCodeReload\FileWatcher;
 use Zend\Expressive\Swoole\Exception\ExtensionNotLoadedException;
 use Zend\Expressive\Swoole\Exception\RuntimeException;
 use Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface;
+
 use function inotify_add_watch;
 use function inotify_init;
 use function inotify_read;

--- a/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
+++ b/src/HotCodeReload/FileWatcher/InotifyFileWatcher.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\HotCodeReload\FileWatcher;
+
+use Zend\Expressive\Swoole\Exception\ExtensionNotLoadedException;
+use Zend\Expressive\Swoole\Exception\RuntimeException;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface;
+use function inotify_add_watch;
+use function inotify_init;
+use function inotify_read;
+use function stream_set_blocking;
+
+class InotifyFileWatcher implements FileWatcherInterface
+{
+    /** @var resource */
+    private $inotify;
+
+    /** @var string[] */
+    private $filePathByWd = [];
+
+    public function __construct()
+    {
+        if (! extension_loaded('inotify')) {
+            throw new ExtensionNotLoadedException('PHP extension "inotify" is required for this file watcher');
+        }
+        $resource = inotify_init();
+        if (false === $resource) {
+            throw new RuntimeException('Unable to initialize an inotify instance');
+        }
+        if (! stream_set_blocking($resource, false)) {
+            throw new RuntimeException('Unable to set non-blocking mode on inotify stream');
+        }
+
+        $this->inotify = $resource;
+    }
+
+    /**
+     * Add a file path to be monitored for changes by this watcher.
+     *
+     * @param string $path
+     */
+    public function addFilePath(string $path) : void
+    {
+        $wd = inotify_add_watch($this->inotify, $path, IN_MODIFY);
+        $this->filePathByWd[$wd] = $path;
+    }
+
+    public function readChangedFilePaths() : array
+    {
+        $events = inotify_read($this->inotify);
+        $paths = [];
+        if (is_array($events)) {
+            foreach ($events as $event) {
+                $wd = $event['wd'] ?? null;
+                if (null === $wd) {
+                    throw new RuntimeException('Missing watch descriptor from inotify event');
+                }
+                $path = $this->filePathByWd[$wd] ?? null;
+                if (null === $path) {
+                    throw new RuntimeException("Unrecognized watch descriptor: \"{$wd}\"");
+                }
+                $paths[$path] = $path;
+            }
+        }
+
+        return array_values($paths);
+    }
+}

--- a/src/HotCodeReload/FileWatcherInterface.php
+++ b/src/HotCodeReload/FileWatcherInterface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\HotCodeReload;
+
+interface FileWatcherInterface
+{
+    /**
+     * Add a file path to be monitored for changes by this watcher.
+     *
+     * @param string $path
+     */
+    public function addFilePath(string $path) : void;
+
+    /**
+     * Returns file paths for files that changed since last read.
+     *
+     * @return string[]
+     */
+    public function readChangedFilePaths() : array;
+}

--- a/src/HotCodeReload/Reloader.php
+++ b/src/HotCodeReload/Reloader.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\HotCodeReload;
+
+use Psr\Log\LoggerInterface;
+use Swoole\Server as SwooleServer;
+use function get_included_files;
+
+class Reloader
+{
+    /**
+     * A file watcher to monitor changes in files.
+     *
+     * @var FileWatcherInterface
+     */
+    private $fileWatcher;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var int
+     */
+    private $interval;
+
+    /**
+     * File paths currently being monitored for changes.
+     *
+     * @var string[]
+     */
+    private $watchedFilePaths = [];
+
+    public function __construct(FileWatcherInterface $fileWatcher, LoggerInterface $logger, int $interval)
+    {
+        $this->fileWatcher = $fileWatcher;
+        $this->interval = $interval;
+        $this->logger = $logger;
+    }
+
+    public function onWorkerStart(SwooleServer $server, int $workerId) : void
+    {
+        // This method will be called for each started worker.
+        // We will register our tick function on the first worker.
+        if (0 === $workerId) {
+            $server->tick($this->interval, $this->generateTickCallback($server));
+        }
+    }
+
+    public function onTick(SwooleServer $server) : void
+    {
+        $this->watchIncludedFiles();
+        $changedFilePaths = $this->fileWatcher->readChangedFilePaths();
+        if ($changedFilePaths) {
+            foreach ($changedFilePaths as $path) {
+                $this->logger->notice("File changed {path}, reloading", ['path' => $path]);
+            }
+            $server->reload();
+        }
+    }
+
+    /**
+     * Generates a callable which will call this instance's onTick method with the given swoole server instance.
+     * By doing this, we forgo the need to have a swoole server property, and handle the case in which it wouldn't
+     * exist.
+     *
+     * @param SwooleServer $server
+     *
+     * @return callable
+     */
+    private function generateTickCallback(SwooleServer $server) : callable
+    {
+        $reloader = $this;
+
+        return function () use ($reloader, $server) {
+            $reloader->onTick($server);
+        };
+    }
+
+    /**
+     * Start watching included files.
+     */
+    private function watchIncludedFiles() : void
+    {
+        foreach (array_diff(get_included_files(), $this->watchedFilePaths) as $filePath) {
+            $this->fileWatcher->addFilePath($filePath);
+            $this->watchedFilePaths[] = $filePath;
+        }
+    }
+}

--- a/src/HotCodeReload/Reloader.php
+++ b/src/HotCodeReload/Reloader.php
@@ -11,6 +11,7 @@ namespace Zend\Expressive\Swoole\HotCodeReload;
 
 use Psr\Log\LoggerInterface;
 use Swoole\Server as SwooleServer;
+
 use function get_included_files;
 
 class Reloader
@@ -68,13 +69,10 @@ class Reloader
     }
 
     /**
-     * Generates a callable which will call this instance's onTick method with the given swoole server instance.
-     * By doing this, we forgo the need to have a swoole server property, and handle the case in which it wouldn't
+     * Generates a callable which will call this instance's onTick method with
+     * the given swoole server instance. By doing this, we forgo the need to
+     * have a swoole server property, and handle the case in which it wouldn't
      * exist.
-     *
-     * @param SwooleServer $server
-     *
-     * @return callable
      */
     private function generateTickCallback(SwooleServer $server) : callable
     {

--- a/src/HotCodeReload/ReloaderFactory.php
+++ b/src/HotCodeReload/ReloaderFactory.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Swoole\HotCodeReload;
+
+use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
+use Zend\Expressive\Swoole\Log\StdoutLogger;
+
+class ReloaderFactory
+{
+    public function __invoke(ContainerInterface $container) : Reloader
+    {
+        $config = $container->has('config') ? $container->get('config') : [];
+        $swooleConfig = $config['zend-expressive-swoole'] ?? [];
+        $hotCodeReloadConfig = $swooleConfig['hot-code-reload'] ?? [];
+
+        return new Reloader(
+            $container->get(FileWatcherInterface::class),
+            $this->getLogger($container),
+            $hotCodeReloadConfig['interval'] ?? 500
+        );
+    }
+
+    private function getLogger(ContainerInterface $container) : LoggerInterface
+    {
+        return $container->has(LoggerInterface::class)
+            ? $container->get(LoggerInterface::class)
+            : new StdoutLogger();
+    }
+}

--- a/src/SwooleRequestHandlerRunner.php
+++ b/src/SwooleRequestHandlerRunner.php
@@ -110,7 +110,7 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
     private $processName;
 
     /**
-     * @var ?Reloader
+     * @var null|Reloader
      */
     private $hotCodeReloader;
 
@@ -205,7 +205,7 @@ class SwooleRequestHandlerRunner extends RequestHandlerRunner
             : sprintf('%s-worker-%d', $this->processName, $workerId);
         $this->setProcessName($processName);
 
-        if (null !== $this->hotCodeReloader) {
+        if ($this->hotCodeReloader) {
             $this->hotCodeReloader->onWorkerStart($server, $workerId);
         }
 

--- a/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
+++ b/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\HotCodeReload\FileWatcher;
+
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
+use PHPUnit\Framework\TestCase;
+
+class InotifyFileWatcherTest extends TestCase
+{
+    /** @var resource */
+    private $file;
+
+    public function testReadChangedFilePathsIsNonBlocking() : void
+    {
+        $path = stream_get_meta_data($this->file)['uri'];
+        $subject = new InotifyFileWatcher();
+        $subject->addFilePath($path);
+
+        static::assertEmpty($subject->readChangedFilePaths());
+        fwrite($this->file, 'foo');
+        static::assertEquals([$path], $subject->readChangedFilePaths());
+    }
+
+    protected function setUp()
+    {
+        if (! extension_loaded('inotify')) {
+            static::markTestSkipped('The Inotify extension is not available');
+        }
+        $file = tmpfile();
+        if (false === $file) {
+            static::markTestSkipped('Unable to create a temporary file');
+        }
+        $this->file = $file;
+
+        parent::setUp();
+    }
+
+    protected function tearDown()
+    {
+        fclose($this->file);
+        parent::tearDown();
+    }
+}

--- a/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
+++ b/test/HotCodeReload/FileWatcher/InotifyFileWatcherTest.php
@@ -9,24 +9,13 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Swoole\HotCodeReload\FileWatcher;
 
-use Zend\Expressive\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
 use PHPUnit\Framework\TestCase;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcher\InotifyFileWatcher;
 
 class InotifyFileWatcherTest extends TestCase
 {
     /** @var resource */
     private $file;
-
-    public function testReadChangedFilePathsIsNonBlocking() : void
-    {
-        $path = stream_get_meta_data($this->file)['uri'];
-        $subject = new InotifyFileWatcher();
-        $subject->addFilePath($path);
-
-        static::assertEmpty($subject->readChangedFilePaths());
-        fwrite($this->file, 'foo');
-        static::assertEquals([$path], $subject->readChangedFilePaths());
-    }
 
     protected function setUp()
     {
@@ -46,5 +35,16 @@ class InotifyFileWatcherTest extends TestCase
     {
         fclose($this->file);
         parent::tearDown();
+    }
+
+    public function testReadChangedFilePathsIsNonBlocking() : void
+    {
+        $path = stream_get_meta_data($this->file)['uri'];
+        $subject = new InotifyFileWatcher();
+        $subject->addFilePath($path);
+
+        static::assertEmpty($subject->readChangedFilePaths());
+        fwrite($this->file, 'foo');
+        static::assertEquals([$path], $subject->readChangedFilePaths());
     }
 }

--- a/test/HotCodeReload/ReloaderFactoryTest.php
+++ b/test/HotCodeReload/ReloaderFactoryTest.php
@@ -24,9 +24,17 @@ class ReloaderFactoryTest extends TestCase
     /** @var FileWatcherInterface */
     private $fileWatcher;
 
+    protected function setUp()
+    {
+        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
+        $this->container = new ServiceManager();
+        $this->container->setAllowOverride(true);
+        $this->container->setService(FileWatcherInterface::class, $this->fileWatcher);
+
+        parent::setUp();
+    }
+
     /**
-     * @param array $services
-     *
      * @dataProvider provideServiceManagerServicesWithEmptyConfigurations
      */
     public function testCreateUnconfigured(array $services) : void
@@ -84,15 +92,5 @@ class ReloaderFactoryTest extends TestCase
                 ],
             ],
         ];
-    }
-
-    protected function setUp()
-    {
-        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
-        $this->container = new ServiceManager();
-        $this->container->setAllowOverride(true);
-        $this->container->setService(FileWatcherInterface::class, $this->fileWatcher);
-
-        parent::setUp();
     }
 }

--- a/test/HotCodeReload/ReloaderFactoryTest.php
+++ b/test/HotCodeReload/ReloaderFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\HotCodeReload;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface;
+use Zend\Expressive\Swoole\HotCodeReload\ReloaderFactory;
+use Zend\Expressive\Swoole\Log\StdoutLogger;
+use Zend\ServiceManager\ServiceManager;
+
+class ReloaderFactoryTest extends TestCase
+{
+    /** @var ServiceManager */
+    private $container;
+
+    /** @var FileWatcherInterface */
+    private $fileWatcher;
+
+    /**
+     * @param array $services
+     *
+     * @dataProvider provideServiceManagerServicesWithEmptyConfigurations
+     */
+    public function testCreateUnconfigured(array $services) : void
+    {
+        $this->container->configure(['services' => $services]);
+        $reloader = (new ReloaderFactory())->__invoke($this->container);
+
+        static::assertAttributeSame($this->fileWatcher, 'fileWatcher', $reloader);
+        static::assertAttributeEquals(new StdoutLogger(), 'logger', $reloader);
+        static::assertAttributeSame(500, 'interval', $reloader);
+    }
+
+    public function testCreateConfigured() : void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $this->container->configure([
+            'services' => [
+                'config' => [
+                    'zend-expressive-swoole' => [
+                        'hot-code-reload' => [
+                            'interval' => 999,
+                        ],
+                    ],
+                ],
+                LoggerInterface::class => $logger,
+            ],
+        ]);
+        $reloader = (new ReloaderFactory())->__invoke($this->container);
+
+        static::assertAttributeSame($this->fileWatcher, 'fileWatcher', $reloader);
+        static::assertAttributeSame(999, 'interval', $reloader);
+        static::assertAttributeSame($logger, 'logger', $reloader);
+    }
+
+    public function provideServiceManagerServicesWithEmptyConfigurations() : iterable
+    {
+        yield 'empty container' => [
+            [
+
+            ],
+        ];
+
+        yield 'empty config' => [
+            [
+                'config' => [],
+            ],
+        ];
+
+        yield 'empty hot-code-reload' => [
+            [
+                'config' => [
+                    'zend-expressive-swoole' => [
+
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    protected function setUp()
+    {
+        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
+        $this->container = new ServiceManager();
+        $this->container->setAllowOverride(true);
+        $this->container->setService(FileWatcherInterface::class, $this->fileWatcher);
+
+        parent::setUp();
+    }
+}

--- a/test/HotCodeReload/ReloaderTest.php
+++ b/test/HotCodeReload/ReloaderTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-swoole for the canonical source repository
+ * @copyright Copyright (c) 2019 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-swoole/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ZendTest\Expressive\Swoole\HotCodeReload;
+
+use PHPUnit\Framework\Constraint\Constraint;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Swoole\Server as SwooleServer;
+use Zend\Expressive\Swoole\HotCodeReload\FileWatcherInterface;
+use Zend\Expressive\Swoole\HotCodeReload\Reloader;
+
+class ReloaderTest extends TestCase
+{
+    /** @var MockObject|FileWatcherInterface */
+    private $fileWatcher;
+
+    /** @var int */
+    private $interval = 123;
+
+    /** @var Reloader */
+    private $subject;
+
+    /**
+     * Creates a constraint that checks if every value is a unique scalar value.
+     * Uniqueness is checked by adding values as an array key until a repeat occurs.
+     */
+    private static function isUniqueScalar() : Constraint
+    {
+        return new class extends Constraint
+        {
+            private $values = [];
+
+            protected function matches($other) : bool
+            {
+                if (isset($this->values[$other])) {
+                    return false;
+                }
+
+                return $this->values[$other] = true;
+            }
+
+            public function toString() : string
+            {
+                return 'is only used once';
+            }
+        };
+    }
+
+    public function testOnWorkerStartOnlyRegistersTickFunctionOnFirstServer() : void
+    {
+        $server0 = $this->createMock(SwooleServer::class);
+        $server0
+            ->expects(static::once())
+            ->method('tick')
+            ->with(
+                $this->interval,
+                static::callback(function (callable $callback) use ($server0) {
+                    $callback($server0);
+
+                    return true;
+                })
+            );
+
+        $server1 = $this->createMock(SwooleServer::class);
+        $server1
+            ->expects(static::never())
+            ->method('tick');
+
+        $this->subject->onWorkerStart($server0, 0);
+        $this->subject->onWorkerStart($server1, 1);
+    }
+
+    public function testIncludedFilesAreOnlyAddedToWatchOnce() : void
+    {
+        $this->fileWatcher
+            ->expects(static::atLeastOnce())
+            ->method('addFilePath')
+            ->with(static::isUniqueScalar());
+
+        $server = $this->createMock(SwooleServer::class);
+        $server->expects(static::never())->method('reload');
+        $this->subject->onTick($server);
+        $this->subject->onTick($server);
+    }
+
+    public function testServerReloadedWhenFilesChange() : void
+    {
+        $this->fileWatcher
+            ->expects(static::once())
+            ->method('readChangedFilePaths')
+            ->willReturn([
+                '/foo.php',
+                '/bar.php',
+            ]);
+
+        $server = $this->createMock(SwooleServer::class);
+        $server
+            ->expects(static::once())
+            ->method('reload');
+
+        $this->subject->onTick($server);
+    }
+
+    protected function setUp()
+    {
+        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
+        $this->subject = new Reloader($this->fileWatcher, new NullLogger(), $this->interval);
+
+        parent::setUp();
+    }
+}

--- a/test/HotCodeReload/ReloaderTest.php
+++ b/test/HotCodeReload/ReloaderTest.php
@@ -28,6 +28,14 @@ class ReloaderTest extends TestCase
     /** @var Reloader */
     private $subject;
 
+    protected function setUp()
+    {
+        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
+        $this->subject = new Reloader($this->fileWatcher, new NullLogger(), $this->interval);
+
+        parent::setUp();
+    }
+
     /**
      * Creates a constraint that checks if every value is a unique scalar value.
      * Uniqueness is checked by adding values as an array key until a repeat occurs.
@@ -107,13 +115,5 @@ class ReloaderTest extends TestCase
             ->method('reload');
 
         $this->subject->onTick($server);
-    }
-
-    protected function setUp()
-    {
-        $this->fileWatcher = $this->createMock(FileWatcherInterface::class);
-        $this->subject = new Reloader($this->fileWatcher, new NullLogger(), $this->interval);
-
-        parent::setUp();
     }
 }

--- a/test/SwooleRequestHandlerRunnerFactoryTest.php
+++ b/test/SwooleRequestHandlerRunnerFactoryTest.php
@@ -16,14 +16,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 use Swoole\Http\Server as SwooleHttpServer;
 use Zend\Expressive\ApplicationPipeline;
 use Zend\Expressive\Response\ServerRequestErrorResponseGenerator;
-use Zend\Expressive\Swoole\PidManager;
-use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
-use Zend\Expressive\Swoole\SwooleRequestHandlerRunnerFactory;
-use Zend\Expressive\Swoole\ServerFactory;
-use Zend\Expressive\Swoole\StaticResourceHandlerInterface;
+use Zend\Expressive\Swoole\HotCodeReload\Reloader;
 use Zend\Expressive\Swoole\Log\AccessLogInterface;
 use Zend\Expressive\Swoole\Log\Psr3AccessLogDecorator;
-use Zend\Expressive\Swoole\HotCodeReload\Reloader;
+use Zend\Expressive\Swoole\PidManager;
+use Zend\Expressive\Swoole\ServerFactory;
+use Zend\Expressive\Swoole\StaticResourceHandlerInterface;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunner;
+use Zend\Expressive\Swoole\SwooleRequestHandlerRunnerFactory;
 
 class SwooleRequestHandlerRunnerFactoryTest extends TestCase
 {


### PR DESCRIPTION
Added hot code reload feature.

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
To allow easier and faster development with swoole. Monitors included php files, and reloads swoole server if there is a change.
  - [x] How will users use the new feature?
Enabling this feature in their swoole.local.php config file.
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.
