### PR TITLE
Install inotify extension to enable skipped tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
 
 before_install:
   - sh -c "mkdir -p ${TRAVIS_BUILD_DIR}/.travis/module-cache/$(php-config --vernum)"
-  - MODULES="swoole.so:swoole" ./.travis/modulecache.sh
+  - MODULES="swoole.so:swoole inotify.so:inotify" ./.travis/modulecache.sh
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:

--- a/.travis/install_inotify.sh
+++ b/.travis/install_inotify.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+pecl install inotify

--- a/.travis/install_swoole.sh
+++ b/.travis/install_swoole.sh
@@ -8,3 +8,5 @@ pecl install swoole << EOF
 `#enable mysqlnd support? [no] :`
 `#enable postgresql coroutine client support support? [no] :`
 EOF
+
+pecl install inotify

--- a/.travis/install_swoole.sh
+++ b/.travis/install_swoole.sh
@@ -8,5 +8,3 @@ pecl install swoole << EOF
 `#enable mysqlnd support? [no] :`
 `#enable postgresql coroutine client support support? [no] :`
 EOF
-
-pecl install inotify


### PR DESCRIPTION
After adding feature "Added hot code reloading" (#60) the new test is skipped because the PHP extension `inotify` is not installed (per https://github.com/zendframework/zend-expressive-swoole/pull/60#issuecomment-461639905).

This PR enables the extension so all tests can run. 

/cc @samuelnogueira @weierophinney 